### PR TITLE
Fix SendAndReceive

### DIFF
--- a/p2p/interface_test.go
+++ b/p2p/interface_test.go
@@ -16,6 +16,7 @@ type nodeGenerator func(ctx context.Context, t *testing.T) Node
 func NodeTests(t *testing.T, generator nodeGenerator) {
 	BootstrapTest(t, generator)
 	SendTest(t, generator)
+	SendAndReceiveTest(t, generator)
 }
 
 func bootstrapAddresses(bootstrapHost Node) []string {

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -206,9 +206,11 @@ func (h *LibP2PHost) SendAndReceive(publicKey *ecdsa.PublicKey, protocol protoco
 	if err != nil {
 		return nil, fmt.Errorf("error creating new stream")
 	}
-	defer stream.Close()
 
 	n, err := stream.Write(payload)
+	// Close for writing so that the remote knows there's nothing more to read
+	// The remote can still write back to us though
+	stream.Close()
 	if err != nil {
 		return nil, fmt.Errorf("Error writing message: %v", err)
 	}

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func LibP2PNodeGenerator(ctx context.Context, t *testing.T) Node {
+func libP2PNodeGenerator(ctx context.Context, t *testing.T) Node {
 	key, err := crypto.GenerateKey()
 	require.Nil(t, err)
 
@@ -23,7 +23,7 @@ func LibP2PNodeGenerator(ctx context.Context, t *testing.T) Node {
 }
 
 func TestHost(t *testing.T) {
-	NodeTests(t, LibP2PNodeGenerator)
+	NodeTests(t, libP2PNodeGenerator)
 }
 
 func TestUnmarshal31ByteKey(t *testing.T) {


### PR DESCRIPTION
Fix the SendAndReceive function as it would enter a deadlock, due to a bidirectional stream not being closed for writing before waiting for a response. Also enable corresponding test.