### PR TITLE
Set libp2p public ip via env var

### DIFF
--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -2,6 +2,8 @@ package p2p
 
 import (
 	"context"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -24,6 +26,26 @@ func libP2PNodeGenerator(ctx context.Context, t *testing.T) Node {
 
 func TestHost(t *testing.T) {
 	NodeTests(t, libP2PNodeGenerator)
+}
+
+func TestP2pBroadcastIp(t *testing.T) {
+	startEnv, startEnvOk := os.LookupEnv("TUPELO_PUBLIC_IP")
+	defer func() {
+		if startEnvOk {
+			os.Setenv("TUPELO_PUBLIC_IP", startEnv)
+		} else {
+			os.Unsetenv("TUPELO_PUBLIC_IP")
+		}
+	}()
+	os.Setenv("TUPELO_PUBLIC_IP", "1.1.1.1")
+	testHost := libP2PNodeGenerator(context.Background(), t)
+	found := false
+	for _, addr := range testHost.Addresses() {
+		if strings.HasPrefix(addr.String(), "/ip4/1.1.1.1/") {
+			found = true
+		}
+	}
+	require.True(t, found)
 }
 
 func TestUnmarshal31ByteKey(t *testing.T) {


### PR DESCRIPTION
This plugs in to libp2p host creation and allows explicitly publishing this host's public ip address. The theory is that peers within the same subnet that *could* route to each other via the VPC ip, potentially publishing that private ip into the DHT. The problem is that other nodes in other regions couldn't route there. Now, it is confusing slightly because it used to work without this explicit addition of public ip, but we have done bumped the libp2p version a couple of times since we were last stable.