### PR TITLE
Use go.mod as basis for CircleCI caching, not go.sum

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,10 @@ jobs:
             - "06:4a:76:ba:0c:08:2f:ee:d6:2c:0f:7f:fa:f0:28:45"
       - restore_cache:
           keys:
-            - go-mod-v1-{{ checksum "go.sum" }}
+            - go-mod-v1-{{ checksum "go.mod" }}
       - run: ./scripts/test-within-docker.sh
       - save_cache:
-          key: go-mod-v1-{{ checksum "go.sum" }}
+          key: go-mod-v1-{{ checksum "go.mod" }}
           paths:
             - "/go/pkg/mod"
       - store_test_results:


### PR DESCRIPTION
Use go.mod as basis for CircleCI dep caching, not go.sum, as the latter only [contains checksums](https://github.com/golang/go/wiki/Modules#is-gosum-a-lock-file-why-does-gosum-include-information-for-module-versions-i-am-no-longer-using) and doesn't lock dependencies.