### PR TITLE
Makefile: Under CircleCI, test in module read-only mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ test: $(gosources) $(generated) go.mod go.sum $(FIRSTGOPATH)/bin/gotestsum
 
 ci-test: $(gosources) $(generated) go.mod go.sum $(FIRSTGOPATH)/bin/gotestsum
 	mkdir -p test_results/unit_tests
-	gotestsum --junitfile=test_results/unit_tests/results.xml
+	gotestsum --junitfile=test_results/unit_tests/results.xml -- -mod=readonly ./...
 
 integration-test: docker-image
 	docker run -e TUPELO_BOOTSTRAP_NODES=/ip4/172.16.238.10/tcp/34001/ipfs/\


### PR DESCRIPTION
Re-enable original behaviour of not allowing updating of go.mod when building under CircleCI. I think we shouldn't allow Go to update go.mod when testing under CI, it should instead fail hard if changes are necessary to build.