### PR TITLE
Dockerfile: Switch to Go 1.12.4/Alpine, to harmonize with Tupelo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM golang:1.11.5
+FROM golang:1.12.4-alpine3.9
 
 WORKDIR /app
+
+RUN apk add --no-cache --update build-base
 
 COPY . .
 


### PR DESCRIPTION
Switch Dockerfile to Go 1.12.4/Alpine 3.9 to harmonize with [Tupelo](https://github.com/quorumcontrol/tupelo/blob/master/Dockerfile), and because go.mod declares that Go 1.12 is required.