### PR TITLE
CircleCI: Download deps before linting

### DIFF
--- a/scripts/test-within-docker.sh
+++ b/scripts/test-within-docker.sh
@@ -5,6 +5,7 @@ mkdir -p ~/.ssh
 git config --global url."ssh://git@github.com/".insteadOf "https://github.com/"
 ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
 
+go mod download
 make lint
 
 if [[ "${CI}" == "true" ]]; then


### PR DESCRIPTION
Download dependencies before linting during CI, to try and avoid linter timeout (which sometimes happens).