### PR TITLE
smaller changeset for using the libp2p-pubsub with the gossip race fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ $(FIRSTGOPATH)/bin/modvendor:
 	go get -u github.com/goware/modvendor
 
 vendor: go.mod go.sum $(FIRSTGOPATH)/bin/modvendor
+	mkdir -p $(FIRSTGOPATH)/pkg/mod/github.com/libp2p/go-libp2p-pubsub@v0.0.3
 	go mod vendor
 	modvendor -copy="**/*.c **/*.h"
 

--- a/go.mod
+++ b/go.mod
@@ -51,3 +51,5 @@ require (
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1
 )
+
+replace github.com/libp2p/go-libp2p-pubsub v0.0.3 => github.com/quorumcontrol/go-libp2p-pubsub v0.0.0-20190515123400-58d894b144ff864d212cf4b13c42e8fdfe783aba


### PR DESCRIPTION
The PR in tupelo was showing errors: https://github.com/quorumcontrol/tupelo/pull/293

This is a replacement for https://github.com/quorumcontrol/tupelo-go-sdk/pull/61 which has a much smaller changeset (and does not error in tupelo). 

Changeset without the revert https://github.com/quorumcontrol/tupelo-go-sdk/commit/4fb42cc37c2ab97828b3492d08d2a123d73a781f

