### PR TITLE
add the Option to add more libp2p options directly to a libp2p host

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/ipfs/go-merkledag v0.0.3
 	github.com/libp2p/go-libp2p v0.0.21
 	github.com/libp2p/go-libp2p-circuit v0.0.4
+	github.com/libp2p/go-libp2p-connmgr v0.0.3
 	github.com/libp2p/go-libp2p-crypto v0.0.1
 	github.com/libp2p/go-libp2p-discovery v0.0.2
 	github.com/libp2p/go-libp2p-host v0.0.2

--- a/p2p/config.go
+++ b/p2p/config.go
@@ -234,6 +234,13 @@ func WithExternalIP(ip string, port int) Option {
 	}
 }
 
+func WithLibp2pOptions(opts ...libp2p.Option) Option {
+	return func(c *Config) error {
+		c.AdditionalP2POptions = opts
+		return nil
+	}
+}
+
 func stringToIPNet(str string) (*net.IPNet, error) {
 	_, n, err := net.ParseCIDR(str)
 	if err != nil {

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -173,6 +173,8 @@ func newLibP2PHostFromConfig(ctx context.Context, c *Config) (*LibP2PHost, error
 		opts = append(opts, libp2p.PrivateNetwork(prot))
 	}
 
+	opts = append(opts, c.AdditionalP2POptions...)
+
 	basicHost, err := libp2p.New(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/libp2p/go-libp2p"
 	circuit "github.com/libp2p/go-libp2p-circuit"
+	connmgr "github.com/libp2p/go-libp2p-connmgr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -75,6 +77,9 @@ func TestNewHostFromOptions(t *testing.T) {
 	t.Run("it works with more esoteric options", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
+		cm := connmgr.NewConnManager(20, 100, 20*time.Second)
+
 		h, err := NewHostFromOptions(
 			ctx,
 			WithKey(key),
@@ -82,6 +87,7 @@ func TestNewHostFromOptions(t *testing.T) {
 			WithSegmenter([]byte("my secret password")),
 			WithPubSubRouter("floodsub"),
 			WithRelayOpts(circuit.OptHop),
+			WithLibp2pOptions(libp2p.ConnectionManager(cm)),
 		)
 		require.Nil(t, err)
 		require.NotNil(t, h)


### PR DESCRIPTION
the config already had a slot for add'l options, but the option wasn't exposed. This just makes it available.