### PR TITLE
Bootstrap: Don't require more peers than available

### DIFF
--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -232,7 +232,12 @@ func (h *LibP2PHost) GetPubSub() *pubsub.PubSub {
 }
 
 func (h *LibP2PHost) Bootstrap(peers []string) (io.Closer, error) {
-	bootstrapper := NewBootstrapper(convertPeers(peers), h.host, h.host.Network(), h.routing, 4, 2*time.Second)
+	minPeers := 4
+	if len(peers) < minPeers {
+		minPeers = len(peers)
+	}
+	bootstrapper := NewBootstrapper(convertPeers(peers), h.host, h.host.Network(), h.routing,
+		minPeers, 2*time.Second)
 	bootstrapper.Start(h.parentCtx)
 	h.bootstrapStarted = true
 


### PR DESCRIPTION
I noticed what looks like a bug in `LibP2PHost.Bootstrap`, i.e. it configures minimum number of bootstrap hosts as 4 even if it might be higher than the provided number of bootstrap peers. This patch modifies the logic to take the minimum of the number of bootstrap peers and 4, so you avoid warnings when you're bootstrapping with less than 4 nodes.