### PR TITLE
better lock handling in the p2p discovery start

### DIFF
--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -253,13 +253,13 @@ func (h *LibP2PHost) Bootstrap(peers []string) (io.Closer, error) {
 
 func (h *LibP2PHost) StartDiscovery(namespace string) error {
 	h.discoverLock.Lock()
-	defer h.discoverLock.Unlock()
 
 	discoverer, ok := h.discoverers[namespace]
 	if !ok {
 		discoverer = newTupeloDiscoverer(h, namespace)
 		h.discoverers[namespace] = discoverer
 	}
+	h.discoverLock.Unlock()
 	return discoverer.start(h.parentCtx)
 }
 


### PR DESCRIPTION
discover start is a long process, do not lock the hash while we wait for that to happen. Noticed this when moving between portals in jason's game. Even though the start was in a go routine, the lock was being held so the stop would block until the start was done.