### PR TITLE
add the option for a client-only DHT

### DIFF
--- a/p2p/config.go
+++ b/p2p/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	DataStore            ds.Batching
 	BandwidthReporter    metrics.Reporter
 	Segmenter            []byte
+	ClientOnlyDHT        bool
 	addressFactory       addressFactory
 }
 
@@ -236,6 +237,16 @@ func WithExternalIP(ip string, port int) Option {
 	}
 }
 
+// WithClientOnlyDHT sets whether or not the DHT will be put into client/server mode
+// client mode means it will not serve requests on the DHT
+func WithClientOnlyDHT(isClientOnly bool) Option {
+	return func(c *Config) error {
+		c.ClientOnlyDHT = isClientOnly
+		return nil
+	}
+}
+
+// With Libp2pOptions allows for additional libp2p options to be passed in
 func WithLibp2pOptions(opts ...libp2p.Option) Option {
 	return func(c *Config) error {
 		c.AdditionalP2POptions = opts

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -141,7 +141,13 @@ func newLibP2PHostFromConfig(ctx context.Context, c *Config) (*LibP2PHost, error
 		libp2p.BandwidthReporter(c.BandwidthReporter),
 		libp2p.Routing(func(h host.Host) (routing.PeerRouting, error) {
 			// make the DHT with the given Host
-			rting, err := dht.New(ctx, h, dhtopts.Datastore(c.DataStore))
+			opts := []dhtopts.Option{
+				dhtopts.Datastore(c.DataStore),
+			}
+			if c.ClientOnlyDHT {
+				opts = append(opts, dhtopts.Client(true))
+			}
+			rting, err := dht.New(ctx, h, opts...)
 			if err == nil {
 				idht = rting
 			}

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -88,6 +88,7 @@ func TestNewHostFromOptions(t *testing.T) {
 			WithPubSubRouter("floodsub"),
 			WithRelayOpts(circuit.OptHop),
 			WithLibp2pOptions(libp2p.ConnectionManager(cm)),
+			WithClientOnlyDHT(true),
 		)
 		require.Nil(t, err)
 		require.NotNil(t, h)


### PR DESCRIPTION
it seems like libp2p is actually suggesting defaulting clients to the non-DHT thing. Clients with bad network conditions won't help the DHT, they'll hurt it.

I'm adding this option because I think we'll want the game clients (not jason) to be client-only DHT members. My hope is this will cut their network traffic.