### PR TITLE
use configs for the broadcast topics

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,14 +1,15 @@
 package client
 
 import (
-	"github.com/quorumcontrol/messages/build/go/services"
-	"github.com/quorumcontrol/messages/build/go/signatures"
 	"bytes"
 	"crypto/ecdsa"
 	"fmt"
 	"reflect"
 	"strconv"
 	"time"
+
+	"github.com/quorumcontrol/messages/build/go/services"
+	"github.com/quorumcontrol/messages/build/go/signatures"
 
 	"github.com/AsynkronIT/protoactor-go/actor"
 	"github.com/AsynkronIT/protoactor-go/eventstream"
@@ -26,10 +27,6 @@ import (
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip3/remote"
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip3/types"
 )
-
-// TransactionBroadcastTopic is the topic from which clients
-// broadcast their transactions to the NotaryGroup
-const TransactionBroadcastTopic = "tupelo-transaction-broadcast"
 
 // How many times to attempt PlayTransactions before giving up.
 // 10 is the library's default, but this makes it explicit.
@@ -182,7 +179,7 @@ func (c *Client) Subscribe(trans *services.AddBlockRequest, timeout time.Duratio
 
 // SendTransaction sends a transaction to a signer.
 func (c *Client) SendTransaction(trans *services.AddBlockRequest) error {
-	return c.pubsub.Broadcast(TransactionBroadcastTopic, trans)
+	return c.pubsub.Broadcast(c.Group.Config().TransactionTopic, trans)
 }
 
 // PlayTransactions plays transactions in chain tree.

--- a/gossip3/types/config.go
+++ b/gossip3/types/config.go
@@ -20,11 +20,20 @@ type ValidatorGenerator func(ctx context.Context, notaryGroup *NotaryGroup) (cha
 // Config is the simplest thing that could work for now
 // it is just an in-memory only configuration for the notary group.
 type Config struct {
-	ID                  string
-	TransactionToken    string
-	BurnAmount          uint64
+	// ID of the notary group (generally a DID)
+	ID string
+	// TransactionToken is the token used for transaction fees (in the form <did>/<tokenName>)
+	TransactionToken string
+	// BurnAmount is the amount of TransactionToken that must be burned for the HasBurn block validator to pass
+	BurnAmount uint64
+	// TransactionTopic is the topic used to send AddBlockRequests to the notary group
+	TransactionTopic string
+	// CommitTopic is the topic used to spread the CurrentStates (to both signers and clients)
+	CommitTopic string
+	// ValidatorGenerators is a slice of generators for chaintree.BlockValidatorFuncs (see ValidatorGenerator)
 	ValidatorGenerators []ValidatorGenerator
-	Transactions        map[transactions.Transaction_Type]chaintree.TransactorFunc
+	// Transactions is the map of all supported transactions by this notary group.
+	Transactions map[transactions.Transaction_Type]chaintree.TransactorFunc
 }
 
 func (c *Config) blockValidators(ctx context.Context, ng *NotaryGroup) ([]chaintree.BlockValidatorFunc, error) {
@@ -59,6 +68,8 @@ func DefaultConfig() *Config {
 			WrapStatelessValidator(IsOwner),
 			WrapStatelessValidator(IsTokenRecipient),
 		},
-		Transactions: consensus.DefaultTransactors,
+		TransactionTopic: "tupelo-transaction-broadcast",
+		CommitTopic:      "tupelo-commits",
+		Transactions:     consensus.DefaultTransactors,
 	}
 }


### PR DESCRIPTION
* add a few comments to notary group config
* add the transaction/commit broadcast topics as configs (useful if we have multiple notary groups)
* have the client use the config