### PR TITLE
export the humanconfig to config method

### DIFF
--- a/gossip3/types/humanconfig.go
+++ b/gossip3/types/humanconfig.go
@@ -87,7 +87,7 @@ type HumanConfig struct {
 	Transactions []string
 }
 
-func humanConfigToConfig(hc *HumanConfig) (*Config, error) {
+func HumanConfigToConfig(hc *HumanConfig) (*Config, error) {
 	c := &Config{
 		ID:               hc.ID,
 		TransactionToken: hc.TransactionToken,
@@ -138,5 +138,5 @@ func TomlToConfig(tomlBytes string) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error decoding toml: %v", err)
 	}
-	return humanConfigToConfig(&hc)
+	return HumanConfigToConfig(&hc)
 }


### PR DESCRIPTION
this method is necessary in Tupelo itself in order to parse the notary group configs.