### PR TITLE
Makefile: Make it configurable which tests to run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ endif
 FIRSTGOPATH = $(firstword $(subst :, ,$(GOPATH)))
 
 gosources = $(shell find . -path "./vendor/*" -prune -o -type f -name "*.go" -print)
+TESTS_TO_RUN := .
 
 all: build
 
@@ -26,16 +27,16 @@ lint: $(FIRSTGOPATH)/bin/golangci-lint build
 	$(FIRSTGOPATH)/bin/golangci-lint run --build-tags integration
 
 test: $(gosources) go.mod go.sum $(FIRSTGOPATH)/bin/gotestsum
-	gotestsum
+	gotestsum -- -run $(TESTS_TO_RUN)
 
 ci-test: $(gosources) go.mod go.sum $(FIRSTGOPATH)/bin/gotestsum
 	mkdir -p test_results/unit_tests
-	gotestsum --junitfile=test_results/unit_tests/results.xml -- -mod=readonly ./...
+	gotestsum --junitfile=test_results/unit_tests/results.xml -- -mod=readonly -run $(TESTS_TO_RUN) ./...
 
 integration-test: docker-image
 	docker run -e TUPELO_BOOTSTRAP_NODES=/ip4/172.16.238.10/tcp/34001/ipfs/\
 16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5 --net tupelo_default \
-quorumcontrol/tupelo-go-sdk go test -mod=vendor -tags=integration -timeout=2m ./...
+quorumcontrol/tupelo-go-sdk go test -mod=vendor -tags=integration -timeout=2m -run $(TESTS_TO_RUN) ./...
 
 docker-image: vendor $(gosources) Dockerfile .dockerignore
 	docker build -t quorumcontrol/tupelo-go-sdk:$(TAG) .


### PR DESCRIPTION
Support configuring which tests to run (it's a regex) via `TESTS_TO_RUN` variable to Make.

Useful when debugging as you can concentrate on specific tests.