### PR TITLE
Remove error case for transaction playback

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -283,8 +283,6 @@ func (c *Client) attemptPlayTransactions(tree *consensus.SignedChainTree, treeKe
 
 	var resp *signatures.CurrentState
 	switch respVal := uncastResp.(type) {
-	case error:
-		return nil, fmt.Errorf("error response: %v", respVal)
 	case *signatures.CurrentState:
 		resp = respVal
 	default:


### PR DESCRIPTION
Remove error case for response from transaction playback, as the latter won't return errors anymore.