### PR TITLE
Fall back to default topics when loading config

### DIFF
--- a/gossip3/types/humanconfig.go
+++ b/gossip3/types/humanconfig.go
@@ -88,12 +88,20 @@ type HumanConfig struct {
 }
 
 func HumanConfigToConfig(hc *HumanConfig) (*Config, error) {
+	txnTopic := hc.TransactionTopic
+	cmtTopic := hc.CommitTopic
+	if txnTopic == "" {
+		txnTopic = "tupelo-transaction-broadcast"
+	}
+	if cmtTopic == "" {
+		cmtTopic = "tupelo-pubsub-commits"
+	}
 	c := &Config{
 		ID:               hc.ID,
 		TransactionToken: hc.TransactionToken,
 		BurnAmount:       hc.BurnAmount,
-		TransactionTopic: hc.TransactionTopic,
-		CommitTopic:      hc.CommitTopic,
+		TransactionTopic: txnTopic,
+		CommitTopic:      cmtTopic,
 	}
 
 	if len(hc.ValidatorGenerators) > 0 {


### PR DESCRIPTION
Fall back to default pubsub topics when loading TOML configuration, to avoid configurations having to specify these correctly.