### PR TITLE
Add logs

### DIFF
--- a/gossip3/remote/pubsub.go
+++ b/gossip3/remote/pubsub.go
@@ -64,6 +64,7 @@ func (nps *NetworkPubSub) Broadcast(topic string, message proto.Message) error {
 		return fmt.Errorf("could not marshal any: %v", err)
 	}
 
+	nps.log.Debugw("broadcasting", "topic", topic)
 	return nps.host.GetPubSub().Publish(topic, marshaled)
 }
 

--- a/p2p/discovery.go
+++ b/p2p/discovery.go
@@ -118,7 +118,7 @@ func (td *tupeloDiscoverer) handleNewPeerInfo(ctx context.Context, p peer.AddrIn
 		if err := host.Connect(ctx, p); err != nil {
 			log.Errorf("error connecting to  %s %v: %v", p.ID, p, err)
 		}
-		log.Debugf("node connected %s %v", td.namespace, p)
+		log.Debugf("node connected for namespace %s: %v", td.namespace, p)
 		numConnected := atomic.AddUint64(&td.connected, uint64(1))
 		td.events.Publish(&DiscoveryEvent{
 			Namespace: td.namespace,


### PR DESCRIPTION
Add logs to help debugging under k8s, proved very useful in understanding why transactions were ignored by the signers.