### PR TITLE
Skip LRU cache on empty GetTip

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -122,9 +122,11 @@ func (c *Client) TipRequest() (*signatures.CurrentState, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting tip: %v", err)
 	}
-	// cache the result to the LRU so future requests to height will
-	// return the answer by sending the answer to the subscriber
-	actor.EmptyRootContext.Send(c.subscriber, res)
+	if res.(*signatures.CurrentState).Signature != nil {
+		// cache the result to the LRU so future requests to height will
+		// return the answer by sending the answer to the subscriber
+		actor.EmptyRootContext.Send(c.subscriber, res)
+	}
 	return res.(*signatures.CurrentState), nil
 }
 


### PR DESCRIPTION
Calling `GetTip` when the tree has yet to be signed will result in a nil CurrentState, which is expected. However, it logs fairly noisily here: https://github.com/quorumcontrol/tupelo-go-sdk/blob/master/client/client.go#L96-L99, which doesn't seem necessary for the explicit `GetTip` call.

This mutes that by skipping the send to the subscriber when there is an empty CurrentState on `GetTip`