### PR TITLE
make the integration tests pass

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -292,6 +292,8 @@ func (c *Client) attemptPlayTransactions(tree *consensus.SignedChainTree, treeKe
 	switch respVal := uncastResp.(type) {
 	case *signatures.CurrentState:
 		resp = respVal
+	case error:
+		return nil, respVal
 	default:
 		c.log.Debugw("transaction resulted in an unrecognized response type", "response", respVal)
 		return nil, fmt.Errorf("error unrecognized response type: %T", respVal)

--- a/client/client_integration_test.go
+++ b/client/client_integration_test.go
@@ -3,6 +3,7 @@
 package client
 
 import (
+	"strings"
 	"sync"
 	"github.com/quorumcontrol/messages/build/go/services"
 	"github.com/quorumcontrol/messages/build/go/signatures"
@@ -429,5 +430,7 @@ func TestNonOwnerTransactions(t *testing.T) {
 	require.Nil(t,err)
 
 	// make sure we got an error back on the invalid transaction (because the tip changed)
-	require.NotNil(t, <-invalidTransactionErrorChan)
+	invalidErr := <-invalidTransactionErrorChan
+	require.NotNil(t, invalidErr)
+	assert.Truef(t, strings.HasPrefix(invalidErr.Error(), "error signature at same height did not match transaction new tip"), "error was: %s", invalidErr.Error())
 }


### PR DESCRIPTION
https://trello.com/c/vA8lWfy7/296-bug-go-sdk-integration-tests-dont-pass

Since we don't send errors back to transactions anymore, this test was hanging indefinitely (and timing out the whole suite). This fixes the suite to pass against a locally running tupelo. I think there should probably be one more PR to use the integration test runner (which is not used in this repo for `make integration-test`)