### PR TITLE
upgrade messages and use gogoprotobufs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/elastic/go-sysinfo v1.0.1 // indirect
 	github.com/ethereum/go-ethereum v1.8.25
 	github.com/gogo/protobuf v1.2.1
-	github.com/golang/protobuf v1.3.1
 	github.com/hashicorp/golang-lru v0.5.1
 	github.com/ipfs/go-bitswap v0.1.5
 	github.com/ipfs/go-blockservice v0.1.0
@@ -34,7 +33,7 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/prometheus/client_golang v0.9.3
 	github.com/quorumcontrol/chaintree v0.0.0-20190701175144-f8f44c3e6d4b
-	github.com/quorumcontrol/messages/build/go v0.0.0-20190603192428-dcb5ad7a31ca
+	github.com/quorumcontrol/messages/build/go v0.0.0-20190716095704-9acdbae78c93
 	github.com/santhosh-tekuri/jsonschema v1.2.4 // indirect
 	github.com/stretchr/testify v1.3.0
 	github.com/uber-go/atomic v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -464,8 +464,8 @@ github.com/quorumcontrol/go-libp2p-pubsub v0.0.4-0.20190528094025-e4e719f73e7a h
 github.com/quorumcontrol/go-libp2p-pubsub v0.0.4-0.20190528094025-e4e719f73e7a/go.mod h1:ZwlKzRSe1eGvSIdU5bD7+8RZN/Uzw0t1Bp9R1znpR/Q=
 github.com/quorumcontrol/messages/build/go v0.0.0-20190530182608-30c127bffefb h1:x/0eUSPARsrbdV1R/3vJWIT8P3EhUaF1AIYPu9L4TKg=
 github.com/quorumcontrol/messages/build/go v0.0.0-20190530182608-30c127bffefb/go.mod h1:b8jDN8PulcGcRJ2pQc0lbC3tPaOspGHoBIbPxfB7Jqg=
-github.com/quorumcontrol/messages/build/go v0.0.0-20190603192428-dcb5ad7a31ca h1:BOFMjEPmEk07alkYO+OtmjqvZtr0MSbJX0cR8Pf/i/g=
-github.com/quorumcontrol/messages/build/go v0.0.0-20190603192428-dcb5ad7a31ca/go.mod h1:QLQVe/V3WcoFNglaJXmoRNs8u+KbsNd5MXeOaa77zgw=
+github.com/quorumcontrol/messages/build/go v0.0.0-20190716095704-9acdbae78c93 h1:G1VRZKIZMjG00VXDK2xpv+fj2/3cKPwRPZpK/ofb1OE=
+github.com/quorumcontrol/messages/build/go v0.0.0-20190716095704-9acdbae78c93/go.mod h1:QLQVe/V3WcoFNglaJXmoRNs8u+KbsNd5MXeOaa77zgw=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/santhosh-tekuri/jsonschema v1.2.3/go.mod h1:TEAUOeZSmIxTTuHatJzrvARHiuO9LYd+cIxzgEHCQI4=
 github.com/santhosh-tekuri/jsonschema v1.2.4 h1:hNhW8e7t+H1vgY+1QeEQpveR6D4+OwKPXCfD2aieJis=

--- a/gossip3/remote/bridge.go
+++ b/gossip3/remote/bridge.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"time"
 
-	ptypes "github.com/golang/protobuf/ptypes"
+	ptypes "github.com/gogo/protobuf/types"
 	mbridge "github.com/quorumcontrol/messages/build/go/bridge"
 
 	"github.com/AsynkronIT/protoactor-go/actor"

--- a/gossip3/remote/deliverywrapper.go
+++ b/gossip3/remote/deliverywrapper.go
@@ -1,7 +1,7 @@
 package remote
 
 import (
-	"github.com/golang/protobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	wbridge "github.com/quorumcontrol/messages/build/go/bridge"
 	"github.com/quorumcontrol/tupelo-go-sdk/tracing"
 )

--- a/gossip3/remote/process.go
+++ b/gossip3/remote/process.go
@@ -8,8 +8,8 @@ import (
 	mbridge "github.com/quorumcontrol/messages/build/go/bridge"
 
 	"github.com/AsynkronIT/protoactor-go/actor"
-	"github.com/golang/protobuf/proto"
-	ptypes "github.com/golang/protobuf/ptypes"
+	"github.com/gogo/protobuf/proto"
+	ptypes "github.com/gogo/protobuf/types"
 	"github.com/quorumcontrol/tupelo-go-sdk/tracing"
 )
 

--- a/gossip3/remote/pubsub.go
+++ b/gossip3/remote/pubsub.go
@@ -6,9 +6,8 @@ import (
 
 	"github.com/AsynkronIT/protoactor-go/actor"
 	"github.com/AsynkronIT/protoactor-go/plugin"
-	"github.com/golang/protobuf/proto"
-	ptypes "github.com/golang/protobuf/ptypes"
-	any "github.com/golang/protobuf/ptypes/any"
+	"github.com/gogo/protobuf/proto"
+	ptypes "github.com/gogo/protobuf/types"
 	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip3/middleware"
@@ -191,7 +190,7 @@ func (bs *broadcastSubscriber) handlePubSubMessage(actorContext actor.Context, p
 }
 
 func pubsubMessageToProtoMessage(pubsubMsg *pubsub.Message) (proto.Message, error) {
-	any := &any.Any{}
+	any := &ptypes.Any{}
 	err := proto.Unmarshal(pubsubMsg.Data, any)
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshaling: %v", err)

--- a/gossip3/remote/pubsub_test.go
+++ b/gossip3/remote/pubsub_test.go
@@ -1,7 +1,6 @@
 package remote
 
 import (
-	"github.com/quorumcontrol/messages/build/go/services"
 	"bytes"
 	"context"
 	"crypto/ecdsa"
@@ -10,14 +9,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/quorumcontrol/messages/build/go/services"
+
 	"github.com/AsynkronIT/protoactor-go/actor"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/gogo/protobuf/proto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip3/middleware"
 	"github.com/quorumcontrol/tupelo-go-sdk/p2p"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/golang/protobuf/proto"
 )
 
 func TestPubSub(t *testing.T) {

--- a/gossip3/remote/pubsubsimulator.go
+++ b/gossip3/remote/pubsubsimulator.go
@@ -7,11 +7,11 @@ import (
 	"github.com/AsynkronIT/protoactor-go/actor"
 	"github.com/AsynkronIT/protoactor-go/eventstream"
 	"github.com/AsynkronIT/protoactor-go/plugin"
+	"github.com/gogo/protobuf/proto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip3/middleware"
 	"github.com/quorumcontrol/tupelo-go-sdk/tracing"
-	"github.com/golang/protobuf/proto"
 )
 
 func NewSimulatedPubSub() *SimulatedPubSub {


### PR DESCRIPTION
uses v0.5.0rc1 of the messages repo and makes the gogoprotobuf changes needed to support it.