### PR TITLE
add the ability to generate a private key from a password and salt

### DIFF
--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/quorumcontrol/messages/build/go/transactions"
 	"github.com/quorumcontrol/tupelo-go-sdk/bls"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsBlockSignedBy(t *testing.T) {
@@ -153,4 +154,10 @@ func TestVerify(t *testing.T) {
 			assert.False(t, isVerified, test.Description)
 		}
 	}
+}
+
+func TestPassPhraseKey(t *testing.T) {
+	key, err := PassPhraseKey([]byte("secretPassword"), []byte("salt"))
+	require.Nil(t, err)
+	assert.Equal(t, []byte{0x5b, 0x94, 0x85, 0x8e, 0xda, 0x63, 0xd4, 0xe8, 0x12, 0xa5, 0xed, 0x98, 0xa2, 0xe0, 0xc8, 0xe0, 0xef, 0xcb, 0xf2, 0x72, 0x69, 0xca, 0xa2, 0x9d, 0xe9, 0x6c, 0x7a, 0x93, 0xcc, 0x73, 0x9, 0x14}, crypto.FromECDSA(key))
 }

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1
+	golang.org/x/crypto v0.0.0-20190618222545-ea8f1a30c443
 )
 
 replace github.com/libp2p/go-libp2p-pubsub v0.1.0 => github.com/quorumcontrol/go-libp2p-pubsub v0.0.4-0.20190528094025-e4e719f73e7a


### PR DESCRIPTION
This implements the "Warp Wallet" from keybase: https://keybase.io/warp/warp_1.0.9_SHA256_a2067491ab582bde779f4505055807c2479354633a2216b22cf1e92d1a6e4a87.html which has a 20BTC reward for cracking an 8 character passphrase out there that is still available.

The only difference here is the N value of scrypt in go must be a power of 2, so I upped it from 218 to 256 (more can only be better :))

