### PR TITLE
Separate listen / broadcast ips in Config

### DIFF
--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -52,6 +52,24 @@ func TestP2pBroadcastIp(t *testing.T) {
 	require.True(t, found)
 }
 
+func TestWithExternalAddrs(t *testing.T) {
+	c := &Config{}
+	err := applyOptions(c, WithExternalIP("1.1.1.1", 53))
+	require.Nil(t, err)
+	err = applyOptions(c, WithWebSocketExternalIP("1.1.1.1", 80))
+	require.Nil(t, err)
+	err = applyOptions(c, WithExternalIP("2.2.2.2", 53))
+	require.Nil(t, err)
+	err = applyOptions(c, WithWebSocketExternalIP("2.2.2.2", 80))
+	require.Nil(t, err)
+	require.ElementsMatch(t, c.ExternalAddrs, []string{
+		"/ip4/1.1.1.1/tcp/53",
+		"/ip4/1.1.1.1/tcp/80/ws",
+		"/ip4/2.2.2.2/tcp/53",
+		"/ip4/2.2.2.2/tcp/80/ws",
+	})
+}
+
 func TestNewRelayLibP2PHost(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.Nil(t, err)


### PR DESCRIPTION
Changes `WithListenIp` to be solely listening ip/port, and then adds slice for `ExternalAddrs` for publishing out known addrs. `ExternalAddrs` replaces the `addressFactory` field, and instead creates the `AddrsFactory` at initialization time from the `ExternalAddrs` config.

Also, added a `WithWebSocketExternalIP` to explicitly set the public websocket address