### PR TITLE
expose the TokenPayloadForTransaction method to javascript

### DIFF
--- a/wasm/main.go
+++ b/wasm/main.go
@@ -80,6 +80,17 @@ func main() {
 				return jscommunity.GetCurrentState(context.TODO(), jsOpts.Get("tip"), jsOpts.Get("blockService"), jsOpts.Get("did"))
 			}))
 
+			jsObj.Set("tokenPayloadForTransaction", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+				jsOpts := args[0]
+				return jsclient.TokenPayloadForTransaction(
+					jsOpts.Get("blockService"),
+					jsOpts.Get("tip"),
+					jsOpts.Get("tokenName"),
+					jsOpts.Get("sendId"),
+					jsOpts.Get("jsSendTxSig"),
+				)
+			}))
+
 			jsObj.Set("playTransactions", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 				// js passes in:
 				// interface IPlayTransactionOptions {


### PR DESCRIPTION
I think needing this illustrates that we need to change some things around to make this easier.

Some ideas:

* switch token name to `{did}/{tokenName}` from `{did}:{tokenName}` (switch to a slash to avoid over using the ':' character
* store sends/receives in some sort of tree so that you can look up by sendid instead of having to scan the array