### PR TITLE
Echo tupelo tag in CI integration tests

### DIFF
--- a/scripts/ci-integration-tests.sh
+++ b/scripts/ci-integration-tests.sh
@@ -16,8 +16,8 @@ mkdir -p ${GOPATH}/bin
 
 export PATH="${GOPATH}/bin:${PATH}"
 
-# Run integration tests against tupelo master
+echo -e "\n\nRunning integration tests against tupelo master"
 make integration-test TUPELO=master
 
-# Run integration tests against tupelo latest release
+echo -e "\n\nRunning integration tests against tupelo latest release"
 make integration-test TUPELO=latest


### PR DESCRIPTION
These are really useful to see in the CI test output. Note that the integration tests are currently known to fail against tupelo latest 0.4.x. For now we should make sure that that's all that failed and get 0.5.0 out soon (which should pass as the integration tests pass against master).