### PR TITLE
get rid of the actions/docker and actions/filter

### DIFF
--- a/.github/workflows/delete.yml
+++ b/.github/workflows/delete.yml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Docker Delete Tag
-      uses: ./.github/actions/docker-delete-tag
+    - name: Docker Login
+      run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
       env:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      with:
-        args: quorumcontrol/tupelo-go-sdk
+    - name: Docker Delete Tag
+      run: IMAGE_REF=$(echo ${{ github.ref }} | rev | cut -d / -f 1 | rev); docker delete quorumcontrol/tupelo-go-sdk:$IMAGE_REF

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,26 +6,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+    - name: git setup
+      run: scripts/ci-gitsetup.sh
     - name: Docker Login
-      uses: actions/docker/login@8cdf801b322af5f369e00d85e9cf3a7122f49108
+      run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
       env:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-    - name: Private Go Mod
-      uses: ./.github/actions/make
+    - name: Build & Push
+      run: scripts/ci-dockerbuildpush.sh
       env:
         SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-      with:
-        args: vendor
-    - name: Docker Build Container
-      uses: actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108
-      with:
-        args: build -t imagebuild .
-    - name: Docker Tag Images
-      uses: actions/docker/tag@8cdf801b322af5f369e00d85e9cf3a7122f49108
-      with:
-        args: imagebuild quorumcontrol/tupelo-go-sdk
-    - name: Docker Push Ref Image
-      uses: actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108
-      with:
-        args: push quorumcontrol/tupelo-go-sdk:${IMAGE_REF}
+        GITHUB_REF: ${{ github.ref }}
+   

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,37 +1,23 @@
+# Currently this will just push the "latest released" to the latest docker
+# if you go back and create an old release, this will still get run
 on: release
-name: Docker Build & Push Latest
+name: Docker Build & Push
 jobs:
   dockerLogin:
     name: Docker Login
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+    - name: git setup
+      run: scripts/ci-gitsetup.sh
     - name: Docker Login
-      uses: actions/docker/login@8cdf801b322af5f369e00d85e9cf3a7122f49108
+      run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
       env:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-    - name: Private Go Mod
-      uses: ./.github/actions/make
+    - name: Build & Push
+      run: scripts/ci-dockerbuildpush.sh
       env:
         SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-      with:
-        args: vendor
-    - name: Docker Build Container
-      uses: actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108
-      with:
-        args: build -t imagebuild .
-    - name: Docker Tag Images
-      uses: actions/docker/tag@8cdf801b322af5f369e00d85e9cf3a7122f49108
-      with:
-        args: imagebuild quorumcontrol/tupelo-go-sdk
-    - name: On Latest Release
-      uses: ./.github/actions/filters
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        args: latest-release
-    - name: Docker Push Latest Image
-      uses: actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108
-      with:
-        args: push quorumcontrol/tupelo-go-sdk:latest
+        GITHUB_REF: latest
+   

--- a/scripts/ci-dockerbuildpush.sh
+++ b/scripts/ci-dockerbuildpush.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+IMAGE_REF=$(echo "$GITHUB_REF" | rev | cut -d / -f 1 | rev)
+
+mkdir -p ~/.ssh
+echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
+chmod 600 ~/.ssh/id_rsa
+eval "$(ssh-agent -s)" > /dev/null 2>&1
+ssh-add ~/.ssh/id_rsa > /dev/null 2>&1
+
+export GOPATH=${HOME}/go
+
+go mod download
+
+mkdir -p ${GOPATH}/bin
+
+export PATH="${GOPATH}/bin:${PATH}"
+
+make vendor
+
+docker build -t quorumcontrol/tupelo-go-sdk:${IMAGE_REF} .
+docker push quorumcontrol/tupelo-go-sdk:${IMAGE_REF}


### PR DESCRIPTION
Those have been removed. 

I think there might be a change here though... in the release.yml and now just have it pushing every release up to latest. I think in actual fact that will be fine - but I'm not sure what actions/filter latest release used to do.
