### PR TITLE
dual datastores

### DIFF
--- a/p2p/config.go
+++ b/p2p/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	ds "github.com/ipfs/go-datastore"
 	dsync "github.com/ipfs/go-datastore/sync"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	circuit "github.com/libp2p/go-libp2p-circuit"
 	"github.com/libp2p/go-libp2p-core/metrics"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -40,6 +41,7 @@ type Config struct {
 	DiscoveryNamespaces  []string
 	AdditionalP2POptions []libp2p.Option
 	DataStore            ds.Batching
+	Blockstore           blockstore.Blockstore
 	BandwidthReporter    metrics.Reporter
 	Segmenter            []byte
 	ClientOnlyDHT        bool
@@ -166,6 +168,16 @@ func WithPubSubOptions(opts ...pubsub.Option) Option {
 func WithDatastore(store ds.Batching) Option {
 	return func(c *Config) error {
 		c.DataStore = store
+		return nil
+	}
+}
+
+// WithBlockStore sets the datastore used by the host
+// defaults to nil which will wrap the underlying
+// node datastore.
+func WithBlockstore(store blockstore.Blockstore) Option {
+	return func(c *Config) error {
+		c.Blockstore = store
 		return nil
 	}
 }

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
+	ds "github.com/ipfs/go-datastore"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/libp2p/go-libp2p"
 	circuit "github.com/libp2p/go-libp2p-circuit"
 	connmgr "github.com/libp2p/go-libp2p-connmgr"
@@ -98,6 +100,8 @@ func TestNewHostFromOptions(t *testing.T) {
 
 		cm := connmgr.NewConnManager(20, 100, 20*time.Second)
 
+		bs := blockstore.NewBlockstore(ds.NewMapDatastore())
+
 		h, err := NewHostFromOptions(
 			ctx,
 			WithKey(key),
@@ -107,9 +111,11 @@ func TestNewHostFromOptions(t *testing.T) {
 			WithRelayOpts(circuit.OptHop),
 			WithLibp2pOptions(libp2p.ConnectionManager(cm)),
 			WithClientOnlyDHT(true),
+			WithBlockstore(bs),
 		)
 		require.Nil(t, err)
 		require.NotNil(t, h)
+		require.Equal(t, bs, h.blockstore)
 	})
 }
 func TestUnmarshal31ByteKey(t *testing.T) {


### PR DESCRIPTION
Right now if you choose a datastore it's used for both the general purpose K/V that libp2p needs *and* the blockstore... this means we were putting our peers, etc into S3