### PR TITLE
allow passing in bitswap options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58 // indirect
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 )
 

--- a/p2p/bitswap.go
+++ b/p2p/bitswap.go
@@ -34,9 +34,9 @@ type BitswapPeer struct {
 // NewBitswapPeer creates a new block-swapping peer from an existing *LibP2PHost
 // It is important that you bootstrap *after* creating this peer. There is a helper function:
 // NewHostAndBitSwapPeer which can create both the host and this peer at the same time.
-func NewBitswapPeer(ctx context.Context, host *LibP2PHost) (*BitswapPeer, error) {
+func NewBitswapPeer(ctx context.Context, host *LibP2PHost, bitswapOpts ...bitswap.Option) (*BitswapPeer, error) {
 	bswapnet := network.NewFromIpfsHost(host.host, host.routing)
-	bswap := bitswap.New(ctx, bswapnet, host.blockstore)
+	bswap := bitswap.New(ctx, bswapnet, host.blockstore, bitswapOpts...)
 	bserv := blockservice.New(host.blockstore, bswap)
 
 	dags := merkledag.NewDAGService(bserv)

--- a/p2p/bitswap_test.go
+++ b/p2p/bitswap_test.go
@@ -5,18 +5,17 @@ import (
 	"testing"
 	"time"
 
+	bitswap "github.com/ipfs/go-bitswap"
 	"github.com/quorumcontrol/chaintree/safewrap"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestBitSwap(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+func twoBitswappingNodes(t *testing.T, ctx context.Context, opts ...Option) (nodeA *LibP2PHost, peerA *BitswapPeer, nodeB *LibP2PHost, peerB *BitswapPeer) {
 	nodeA, peerA, err := NewHostAndBitSwapPeer(ctx)
 	require.Nil(t, err)
 
-	nodeB, peerB, err := NewHostAndBitSwapPeer(ctx)
+	nodeB, peerB, err = NewHostAndBitSwapPeer(ctx)
 	require.Nil(t, err)
 
 	// Notice that the bootstrap is below the creation of the peer
@@ -34,6 +33,14 @@ func TestBitSwap(t *testing.T) {
 	err = nodeB.WaitForBootstrap(1, 1*time.Second)
 	require.Nil(t, err)
 
+	return // nodea,peera,nodeb,peerb
+}
+
+func TestBitSwap(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, peerA, _, peerB := twoBitswappingNodes(t, ctx)
+
 	sw := &safewrap.SafeWrap{}
 
 	n := sw.WrapObject(map[string]string{"hello": "bitswap"})
@@ -42,7 +49,29 @@ func TestBitSwap(t *testing.T) {
 	swapCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	err = peerA.Add(swapCtx, n)
+	err := peerA.Add(swapCtx, n)
+	require.Nil(t, err)
+
+	_, err = peerB.Get(swapCtx, n.Cid())
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestBitswapNoProvide(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, peerA, _, peerB := twoBitswappingNodes(t, ctx, WithBitswapOptions(bitswap.ProvideEnabled(false)))
+
+	sw := &safewrap.SafeWrap{}
+
+	n := sw.WrapObject(map[string]string{"hello": "bitswap"})
+	require.Nil(t, sw.Err)
+
+	swapCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	err := peerA.Add(swapCtx, n)
 	require.Nil(t, err)
 
 	_, err = peerB.Get(swapCtx, n.Cid())

--- a/p2p/config.go
+++ b/p2p/config.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"os"
 
+	bitswap "github.com/ipfs/go-bitswap"
+
 	"github.com/ethereum/go-ethereum/crypto"
 	ds "github.com/ipfs/go-datastore"
 	dsync "github.com/ipfs/go-datastore/sync"
@@ -26,7 +28,6 @@ type Config struct {
 	RelayOpts            []circuit.RelayOpt
 	EnableRelayHop       bool
 	EnableAutoRelay      bool
-	EnableBitSwap        bool
 	EnableWebsocket      bool
 	WebsocketPort        int
 	PubSubRouter         string
@@ -45,6 +46,7 @@ type Config struct {
 	BandwidthReporter    metrics.Reporter
 	Segmenter            []byte
 	ClientOnlyDHT        bool
+	BitswapOptions       []bitswap.Option
 }
 
 // This is a function, because we want to return a new datastore each time
@@ -279,6 +281,13 @@ func WithClientOnlyDHT(isClientOnly bool) Option {
 func WithLibp2pOptions(opts ...libp2p.Option) Option {
 	return func(c *Config) error {
 		c.AdditionalP2POptions = opts
+		return nil
+	}
+}
+
+func WithBitswapOptions(opts ...bitswap.Option) Option {
+	return func(c *Config) error {
+		c.BitswapOptions = opts
 		return nil
 	}
 }

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -82,11 +82,19 @@ func PeerFromEcdsaKey(publicKey *ecdsa.PublicKey) (peer.ID, error) {
 }
 
 func NewHostAndBitSwapPeer(ctx context.Context, userOpts ...Option) (*LibP2PHost, *BitswapPeer, error) {
-	h, err := NewHostFromOptions(ctx, userOpts...)
+	c := &Config{}
+	opts := append(defaultOptions(), userOpts...)
+	err := applyOptions(c, opts...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error applying opts: %v", opts)
+	}
+
+	h, err := newLibP2PHostFromConfig(ctx, c)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error generating libp2p host: %v", err)
 	}
-	peer, err := NewBitswapPeer(ctx, h)
+
+	peer, err := NewBitswapPeer(ctx, h, c.BitswapOptions...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error generating bitswap peer: %v", err)
 	}


### PR DESCRIPTION
This allows a the libp2p host creator to specify the bitswap options they want. The purpose is that we were seeing insane provide traffic when doing bitswap with provide enabled and the bitswap package has an option for disabling provide.

This means that random nodes can't find each other to bitswap, but any node that is connected with another will still continue to bitswap (as shown by the new test here).