### PR TITLE
add method for converting peer id to ecdsa pubkey

### DIFF
--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -81,6 +81,20 @@ func PeerFromEcdsaKey(publicKey *ecdsa.PublicKey) (peer.ID, error) {
 	return peer.IDFromPublicKey(p2pPublicKeyFromEcdsaPublic(publicKey))
 }
 
+func EcdsaKeyFromPeer(pid peer.ID) (*ecdsa.PublicKey, error) {
+	pubkey, err := pid.ExtractPublicKey()
+	if err != nil {
+		return nil, fmt.Errorf("error extracting pubkey from peer: %v", err)
+	}
+
+	asSecp256k1PublicKey, ok := pubkey.(*libp2pcrypto.Secp256k1PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("unsupported key type %s from peer id, must be Secp256k1", pubkey.Type().String())
+	}
+
+	return (*ecdsa.PublicKey)(asSecp256k1PublicKey), nil
+}
+
 func NewHostAndBitSwapPeer(ctx context.Context, userOpts ...Option) (*LibP2PHost, *BitswapPeer, error) {
 	c := &Config{}
 	opts := append(defaultOptions(), userOpts...)

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -190,3 +190,19 @@ func TestNewDiscoverers(t *testing.T) {
 	err = h2.WaitForDiscovery(ns, 1, 2*time.Second)
 	require.Nil(t, err)
 }
+
+func TestPeerIDToPubkeyConversions(t *testing.T) {
+	keyBytes, err := hexutil.Decode("0x133f18ab84b61b2f217e972d1a5abe9c3a5ae8b52b13b4c4635bb69cbd5212b0")
+	require.Nil(t, err)
+
+	key, err := crypto.ToECDSA(keyBytes)
+	require.Nil(t, err)
+
+	peerID, err := PeerFromEcdsaKey(&key.PublicKey)
+	require.Nil(t, err)
+	require.Equal(t, peerID.Pretty(), "16Uiu2HAmQeLpoMMcZr1hLH6Kw53xFE5Xm8ri4ckGk5vL63sJLLBZ")
+
+	convertedPubkey, err := EcdsaKeyFromPeer(peerID)
+	require.Nil(t, err)
+	require.Equal(t, crypto.FromECDSAPub(convertedPubkey), crypto.FromECDSAPub(&key.PublicKey))
+}


### PR DESCRIPTION
I've had a couple scenarios where i wanted to grab an ecdsa key from a pubkey (even just for debugging), and I've had this code stashed locally. I was going to use it programatically in jasonsgame today, however I pivoted to a different approach, but thought maybe its still useful to have?