### PR TITLE
set storage path to fix failing integration tests

### DIFF
--- a/integration/configs/bootstrap.toml
+++ b/integration/configs/bootstrap.toml
@@ -1,6 +1,7 @@
 Port = 34001
 BootstrapOnly = true
 NotaryGroupConfig = "./integration.toml"
+StoragePath = "/tupelo/storage"
 
 [PrivateKeySet]
 SignKeyHex = "0x1ef1cf13d52b2dbf3134d7fff6aa617c5cdac42ed89bd20007bfc93d00f0d0c6"

--- a/integration/configs/node0.toml
+++ b/integration/configs/node0.toml
@@ -1,4 +1,5 @@
 NotaryGroupConfig = "./integration.toml"
+StoragePath = "/tupelo/storage"
 
 [PrivateKeySet]
 SignKeyHex = "0x4344e3372f1b790016ed86400611fab64d0bba91136518685a7ce34106f1c759"

--- a/integration/configs/node1.toml
+++ b/integration/configs/node1.toml
@@ -1,4 +1,5 @@
 NotaryGroupConfig = "./integration.toml"
+StoragePath = "/tupelo/storage"
 
 
 [PrivateKeySet]

--- a/integration/configs/node2.toml
+++ b/integration/configs/node2.toml
@@ -1,4 +1,5 @@
 NotaryGroupConfig = "./integration.toml"
+StoragePath = "/tupelo/storage"
 
 [PrivateKeySet]
 SignKeyHex = "0x558a546adacea3d761741bf4a6415ef2eeb85bfa457036b59564fa88ee276cf5"


### PR DESCRIPTION
I'm not sure how this worked after https://github.com/quorumcontrol/tupelo/pull/352/files#diff-3254677a7917c6c01f55212f86c57fbfR18 was merged, but this fixes it. Longer term fix is to switch over to tupelo-local which... I *also* don't know how it is working with that change :).