### PR TITLE
Use docker-delete-tag action instead of local image delete

### DIFF
--- a/.github/actions/docker-delete-tag/entrypoint.sh
+++ b/.github/actions/docker-delete-tag/entrypoint.sh
@@ -2,40 +2,40 @@
 
 REPO=$1
 
-if [[ -z "$REPO" ]]; then
+if [[ -z "${REPO}" ]]; then
   echo "Must provide repo as command"
   exit 1
 fi
 
-if [[ -z "$GITHUB_EVENT_PATH" ]]; then
+if [[ -z "${GITHUB_EVENT_PATH}" ]]; then
   echo "\$GITHUB_EVENT_PATH" not found
   exit 1
 fi
 
-TAG_FULL=$(jq --raw-output ".ref" "$GITHUB_EVENT_PATH")
+TAG_FULL=$(jq --raw-output ".ref" "${GITHUB_EVENT_PATH}")
 # mimic https://github.com/actions/docker/blob/b12ae68bebbb2781edb562c0260881a3f86963b4/tag/tag.rb#L39
-TAG=`echo $TAG_FULL | rev | cut -d / -f 1 | rev`
+TAG=$(echo "${TAG_FULL}" | rev | cut -d / -f 1 | rev)
 
-if [[ -z "$TAG" ]]; then
-  echo "Tag could not be parsed from $GITHUB_EVENT_PATH"
+if [[ -z "${TAG}" ]]; then
+  echo "Tag could not be parsed from ${GITHUB_EVENT_PATH}"
   exit 1
 fi
 
-TOKEN=`curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'$DOCKER_USERNAME'", "password": "'$DOCKER_PASSWORD'"}' https://hub.docker.com/v2/users/login/ | jq -r .token`
+TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${DOCKER_USERNAME}'", "password": "'${DOCKER_PASSWORD}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
 
 URL="https://hub.docker.com/v2/repositories/${REPO}/tags/${TAG}/"
 
-STATUS_CODE=`curl -s -o request.out \
+STATUS_CODE=$(curl -s -o request.out \
 -w "%{http_code}" \
 -X DELETE \
 -H "Authorization: JWT ${TOKEN}" \
-"${URL}"`
+"${URL}")
 
-if [[ $STATUS_CODE == "204" ]]; then
+if [[ ${STATUS_CODE} == "204" ]]; then
   exit 0
 else
-  echo $URL
-  echo $STATUS_CODE
+  echo "${URL}"
+  echo "${STATUS_CODE}"
   cat request.out
   exit 1
 fi

--- a/.github/workflows/delete.yml
+++ b/.github/workflows/delete.yml
@@ -12,4 +12,4 @@ jobs:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
     - name: Docker Delete Tag
-      run: IMAGE_REF=$(echo ${{ github.ref }} | rev | cut -d / -f 1 | rev); docker rmi quorumcontrol/tupelo-go-sdk:$IMAGE_REF
+      uses: ../actions/docker-delete-tag

--- a/.github/workflows/delete.yml
+++ b/.github/workflows/delete.yml
@@ -5,6 +5,7 @@ jobs:
     name: Docker Delete Tag
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     - name: Docker Login
       run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
       env:

--- a/.github/workflows/delete.yml
+++ b/.github/workflows/delete.yml
@@ -5,7 +5,6 @@ jobs:
     name: Docker Delete Tag
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
     - name: Docker Login
       run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
       env:


### PR DESCRIPTION
The change I made in #165 didn't actually make the action start working, and as I thought about it further, I realized that deleting a local image probably isn't what we want anyway. There was an unused docker-delete-tag action already in here that hit the Docker Hub API to tell it to delete the tag from there, so this change points it at that instead.

~~The second commit removes the master checkout from the delete tag workflow. I think that may have been overriding `github.ref` to be master again instead of the deleted branch or tag.~~ Re-added this (but on v2 instead of master) in the third commit because I realized it probably needs it for `uses: ../actions/...` to work.