### PR TITLE
remove client debug logging, but expose a logging method

### DIFF
--- a/wasm/jsclient/jsclient.go
+++ b/wasm/jsclient/jsclient.go
@@ -113,8 +113,6 @@ func (jsc *JSClient) GetTip(jsDid js.Value) interface{} {
 			return
 		}
 
-		fmt.Println("proof: ", proof, "err: ", err)
-
 		sw := &safewrap.SafeWrap{}
 
 		wrapped := sw.WrapObject(proof)

--- a/wasm/jsclient/jsclient.go
+++ b/wasm/jsclient/jsclient.go
@@ -107,7 +107,6 @@ func (jsc *JSClient) GetTip(jsDid js.Value) interface{} {
 	t := then.New()
 	go func() {
 		ctx := context.TODO()
-		fmt.Println("getting did: ", did)
 		proof, err := jsc.client.GetTip(ctx, did)
 		if err != nil {
 			t.Reject(fmt.Errorf("error getting tip: %w", err).Error())

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -5,8 +5,8 @@ package main
 import (
 	"context"
 	"fmt"
-	"syscall/js"
 	logging "github.com/ipfs/go-log"
+	"syscall/js"
 
 	"github.com/quorumcontrol/tupelo-go-sdk/wasm/jscrypto"
 
@@ -82,7 +82,6 @@ func main() {
 			}))
 
 			jsObj.Set("getTip", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-				go fmt.Println("getTip: ", args[0].String())
 				return clientSingleton.GetTip(args[0])
 			}))
 

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -131,6 +131,11 @@ func main() {
 			jsObj.Set("signMessage", js.FuncOf(jscrypto.JSSignMessage))
 			jsObj.Set("verifyMessage", js.FuncOf(jscrypto.JSVerifyMessage))
 
+			jsObj.Set("setLogLevel", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+				logging.SetLogLevel(args[0].String(), args[1].String())
+				return nil
+			}))
+
 			jsObj.Set("startClient", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 				// js passes in:
 				// interface IClientOptions {
@@ -152,7 +157,6 @@ func main() {
 				cli := jsclient.New(bridge, config, store)
 				go cli.Start(ctx)
 				clientSingleton = cli
-				logging.SetLogLevel("g4-client", "debug")
 				return nil
 			}))
 


### PR DESCRIPTION
this gets rid of the verbose logging on wasm client, but also exposes logging so that the tupelo-wasm-sdk can decide for itself how much to log. Using this is mildly dangerous because if a log happens outside of a go routine then it will panic, but it's really useful for debugging.