### PR TITLE
libp2p upgrade changes

### DIFF
--- a/wasm/jsclient/jsclient.go
+++ b/wasm/jsclient/jsclient.go
@@ -113,8 +113,6 @@ func (jsc *JSClient) GetTip(jsDid js.Value) interface{} {
 			return
 		}
 
-		fmt.Println("proof: ", proof, "err: ", err)
-
 		sw := &safewrap.SafeWrap{}
 
 		wrapped := sw.WrapObject(proof)

--- a/wasm/jsclient/jsclient.go
+++ b/wasm/jsclient/jsclient.go
@@ -107,7 +107,6 @@ func (jsc *JSClient) GetTip(jsDid js.Value) interface{} {
 	t := then.New()
 	go func() {
 		ctx := context.TODO()
-		fmt.Println("getting did: ", did)
 		proof, err := jsc.client.GetTip(ctx, did)
 		if err != nil {
 			t.Reject(fmt.Errorf("error getting tip: %w", err).Error())

--- a/wasm/jspubsub/subscription.go
+++ b/wasm/jspubsub/subscription.go
@@ -3,9 +3,9 @@
 package jspubsub
 
 import (
-	"github.com/quorumcontrol/tupelo-go-sdk/gossip/client/pubsubinterfaces"
 	"context"
 	"fmt"
+	"github.com/quorumcontrol/tupelo-go-sdk/gossip/client/pubsubinterfaces"
 	"syscall/js"
 
 	"github.com/quorumcontrol/tupelo-go-sdk/wasm/helpers"
@@ -53,12 +53,12 @@ func (bs *BridgedSubscription) QueueJS(msg js.Value) {
 	//     topicIDs: [ 'test' ]
 	//   }
 	pubsubMsg := &pb.Message{
-			From:     []byte(msg.Get("from").String()),
-			Seqno:    helpers.JsBufferToBytes(msg.Get("seqno")),
-			Data:     helpers.JsBufferToBytes(msg.Get("data")),
-			TopicIDs: helpers.JsStringArrayToStringSlice(msg.Get("topicIDs")),
-		}
-	
+		From:     []byte(msg.Get("from").String()),
+		Seqno:    helpers.JsBufferToBytes(msg.Get("seqno")),
+		Data:     helpers.JsBufferToBytes(msg.Get("data")),
+		TopicIDs: helpers.JsStringArrayToStringSlice(msg.Get("topicIDs")),
+	}
+
 	bs.ch <- pubsubMsg
 
 }

--- a/wasm/jsstore/jsstore.go
+++ b/wasm/jsstore/jsstore.go
@@ -49,10 +49,13 @@ func (jss *JSStore) Remove(ctx context.Context, c cid.Cid) error {
 		respCh <- err
 		return nil
 	})
+
 	defer func() {
 		onSuccess.Release()
 		onError.Release()
+		close(respCh)
 	}()
+
 	go func() {
 		promise := jss.bridged.Call("delete", helpers.CidToJSCID(c))
 		promise.Call("then", onSuccess, onError)
@@ -95,6 +98,7 @@ func (jss *JSStore) GetMany(ctx context.Context, cids []cid.Cid) <-chan *format.
 
 func (jss *JSStore) Add(ctx context.Context, n format.Node) error {
 	respCh := make(chan error)
+
 	onSuccess := js.FuncOf(func(_this js.Value, args []js.Value) interface{} {
 		respCh <- nil
 		return nil
@@ -104,10 +108,13 @@ func (jss *JSStore) Add(ctx context.Context, n format.Node) error {
 		respCh <- err
 		return nil
 	})
+
 	defer func() {
 		onSuccess.Release()
 		onError.Release()
+		close(respCh)
 	}()
+
 	go func() {
 		promise := jss.bridged.Call("put", nodeToJSBlock(n))
 		promise.Call("then", onSuccess, onError)
@@ -154,10 +161,13 @@ func (jss *JSStore) Get(ctx context.Context, c cid.Cid) (format.Node, error) {
 		respCh <- err
 		return nil
 	})
+
 	defer func() {
 		onSuccess.Release()
 		onError.Release()
+		close(respCh)
 	}()
+
 	go func() {
 		promise := jss.bridged.Call("get", helpers.CidToJSCID(c))
 		promise.Call("then", onSuccess, onError)

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -5,8 +5,8 @@ package main
 import (
 	"context"
 	"fmt"
-	"syscall/js"
 	logging "github.com/ipfs/go-log"
+	"syscall/js"
 
 	"github.com/quorumcontrol/tupelo-go-sdk/wasm/jscrypto"
 
@@ -82,7 +82,6 @@ func main() {
 			}))
 
 			jsObj.Set("getTip", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-				go fmt.Println("getTip: ", args[0].String())
 				return clientSingleton.GetTip(args[0])
 			}))
 

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -131,6 +131,11 @@ func main() {
 			jsObj.Set("signMessage", js.FuncOf(jscrypto.JSSignMessage))
 			jsObj.Set("verifyMessage", js.FuncOf(jscrypto.JSVerifyMessage))
 
+			jsObj.Set("setLogLevel", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+				logging.SetLogLevel(args[0].String(), args[1].String())
+				return nil
+			}))
+
 			jsObj.Set("startClient", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 				// js passes in:
 				// interface IClientOptions {
@@ -152,7 +157,6 @@ func main() {
 				cli := jsclient.New(bridge, config, store)
 				go cli.Start(ctx)
 				clientSingleton = cli
-				logging.SetLogLevel("g4-client", "debug")
 				return nil
 			}))
 


### PR DESCRIPTION
over in https://github.com/quorumcontrol/tupelo-wasm-sdk/pull/66 we've upgraded libp2p to the latest which is all promises now. This adjusts the way the wasm calls libp2p to represent the new promise API.