### PR TITLE
Add ability for client to subscribe to all rounds

### DIFF
--- a/gossip/client/client.go
+++ b/gossip/client/client.go
@@ -169,6 +169,16 @@ func (c *Client) SendWithoutWait(ctx context.Context, abr *services.AddBlockRequ
 	return nil
 }
 
+func (c *Client) SubscribeToRounds(ctx context.Context, ch chan *types.RoundWrapper) (subscription, error) {
+	return c.subscriber.stream.Subscribe(func(evt interface{}) {
+		ch <- evt.(*validationNotification).CompletedRound
+	}), nil
+}
+
+func (c *Client) UnsubscribeFromRounds(s subscription) {
+	c.subscriber.unsubscribe(s)
+}
+
 func (c *Client) SubscribeToAbr(ctx context.Context, abr *services.AddBlockRequest, ch chan *gossip.Proof) (subscription, error) {
 	return c.subscriber.subscribe(ctx, abr, ch)
 }


### PR DESCRIPTION
This exposes the full event stream from roundsubscriber allowing a client to listen for all rounds. I opted to name the method `SubscribeToRounds` and return the `types.RoundWrapper` for each round, but I could also see making `validationNotification` public and returning that instead.