### PR TITLE
do not panic on getTip before round

### DIFF
--- a/gossip/client/client.go
+++ b/gossip/client/client.go
@@ -24,6 +24,7 @@ import (
 
 var ErrTimeout = errors.New("error timeout")
 var ErrNotFound = hamt.ErrNotFound
+var ErrNoRound = errors.New("no current round yet")
 
 var DefaultTimeout = 30 * time.Second
 
@@ -84,6 +85,9 @@ func (c *Client) PlayTransactions(ctx context.Context, tree *consensus.SignedCha
 
 func (c *Client) GetTip(ctx context.Context, did string) (*gossip.Proof, error) {
 	confirmation := c.subscriber.Current()
+	if confirmation == nil {
+		return nil, ErrNoRound
+	}
 	currentRound, err := confirmation.FetchCompletedRound(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching round: %w", err)

--- a/gossip/client/client_test.go
+++ b/gossip/client/client_test.go
@@ -441,6 +441,30 @@ func TestClientGetTip(t *testing.T) {
 	})
 }
 
+func TestGetTipAppropriatelyErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ts := testnotarygroup.NewTestSet(t, groupMembers)
+	group, nodes, err := newTupeloSystem(ctx, ts)
+	require.Nil(t, err)
+	require.Len(t, nodes, groupMembers)
+	booter, err := p2p.NewHostFromOptions(ctx)
+	require.Nil(t, err)
+
+	bootAddrs := make([]string, len(booter.Addresses()))
+	for i, addr := range booter.Addresses() {
+		bootAddrs[i] = addr.String()
+	}
+
+	startNodes(t, ctx, nodes, bootAddrs)
+
+	cli, err := newClient(ctx, group, bootAddrs)
+	require.Nil(t, err)
+	_, err = cli.GetTip(ctx, "did:doesntmatter")
+	require.Equal(t, err, ErrNoRound)
+}
+
 func TestTokenTransactions(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
This is a much smaller robust change, it just makes the client not *panic* when there is no round and one does a getTip... the bigger fix to come later.