### PR TITLE
expose the WaitForRound to javascript

### DIFF
--- a/wasm/main.go
+++ b/wasm/main.go
@@ -138,6 +138,10 @@ func main() {
 				return t
 			}))
 
+			jsObj.Set("waitForRound", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+				return clientSingleton.WaitForRound()
+			}))
+
 			jsObj.Set("playTransactions", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 				// js passes in:
 				// interface IPlayTransactionOptions {


### PR DESCRIPTION
This just allows javascript to wait for a round to come in. 

What I'd like to do as a next step:

1. turn the exposed javascript object into an event emitter
2. emit rounds as they come in from the client

I think that would be nice for visualizations. For now, I think this gets us over the line to a usable client that won't error when calling getTip before rounds come in (assuming https://github.com/quorumcontrol/tupelo/pull/430 is merged)