### PR TITLE
add GetLatest to the client

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -26,6 +26,8 @@ import (
 func init() {
 	typecaster.AddType(StandardHeaders{})
 	cbornode.RegisterCborType(StandardHeaders{})
+	typecaster.AddType(signatures.TreeState{})
+	cbornode.RegisterCborType(signatures.TreeState{})
 }
 
 type SignatureMap map[string]*signatures.Signature

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -26,8 +26,6 @@ import (
 func init() {
 	typecaster.AddType(StandardHeaders{})
 	cbornode.RegisterCborType(StandardHeaders{})
-	typecaster.AddType(signatures.TreeState{})
-	cbornode.RegisterCborType(signatures.TreeState{})
 }
 
 type SignatureMap map[string]*signatures.Signature

--- a/consensus/signedtree.go
+++ b/consensus/signedtree.go
@@ -11,6 +11,7 @@ import (
 	"github.com/quorumcontrol/chaintree/chaintree"
 	"github.com/quorumcontrol/chaintree/nodestore"
 	"github.com/quorumcontrol/chaintree/typecaster"
+	"github.com/quorumcontrol/messages/v2/build/go/gossip"
 	"github.com/quorumcontrol/messages/v2/build/go/transactions"
 )
 
@@ -25,8 +26,8 @@ var DefaultTransactors = map[transactions.Transaction_Type]chaintree.TransactorF
 }
 
 type SignedChainTree struct {
-	ChainTree  *chaintree.ChainTree
-	Signatures SignatureMap
+	ChainTree *chaintree.ChainTree
+	Proof     *gossip.Proof
 }
 
 func (sct *SignedChainTree) Id() (string, error) {
@@ -73,8 +74,7 @@ func (sct *SignedChainTree) Authentications() ([]string, error) {
 
 func NewSignedChainTreeFromChainTree(tree *chaintree.ChainTree) *SignedChainTree {
 	return &SignedChainTree{
-		ChainTree:  tree,
-		Signatures: make(SignatureMap),
+		ChainTree: tree,
 	}
 }
 
@@ -93,7 +93,6 @@ func NewSignedChainTree(ctx context.Context, key ecdsa.PublicKey, nodeStore node
 	}
 
 	return &SignedChainTree{
-		ChainTree:  tree,
-		Signatures: make(SignatureMap),
+		ChainTree: tree,
 	}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -33,15 +33,14 @@ require (
 	github.com/quorumcontrol/chaintree v1.0.2-0.20200124091942-25ceb93627b9
 	github.com/quorumcontrol/messages v1.1.1
 	github.com/quorumcontrol/messages/v2 v2.1.3-0.20200129115245-2bfec5177653
-	github.com/quorumcontrol/tupelo v0.5.12-0.20200129144132-3be48615b2ec
+	github.com/quorumcontrol/tupelo v0.5.12-0.20200226160350-8bc73f1e0652
 	github.com/spy16/parens v0.0.8
 	github.com/stretchr/testify v1.3.0
 	github.com/uber/jaeger-client-go v2.22.1+incompatible
-	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
 	go.dedis.ch/kyber/v3 v3.0.9
 	go.elastic.co/apm/module/apmot v1.6.0
 	go.uber.org/zap v1.10.0
-	golang.org/x/crypto v0.0.0-20191111213947-16651526fdb4
+	golang.org/x/crypto v0.0.0-20200204104054-c9f3fb736b72
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 )
 

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ cloud.google.com/go v0.26.0 h1:e0WKqKTd5BnrG8aKH3J3h+QvEIQtSUcf2n5UZ5ZgLtQ=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7 h1:PqzgE6kAMi81xWQA2QIVxjWkFHptGgC547vchpUbtFo=
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
+github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9 h1:HD8gA2tkByhMAwYaFAX9w2l7vxvBQ5NMoxDrkhqhtn4=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/AsynkronIT/goconsole v0.0.0-20160504192649-bfa12eebf716/go.mod h1:2wH9LwjNrSqVmCIi35aqCJ0OGTE4DZ53LCRaGQESBp8=
 github.com/AsynkronIT/gonet v0.0.0-20161127091928-0553637be225/go.mod h1:RwIiSK8AJBCPP7hBBfXD1iferErYAmGbqv/Lu84ZFIA=
@@ -34,6 +35,7 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/avast/retry-go v2.4.3+incompatible h1:c/FTk2POrEQyZfaHBMkMrXdu3/6IESJUHwu8r3k1JEU=
 github.com/avast/retry-go v2.4.3+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.28.4 h1:LMGtba0y+VeepMzjz1HLie6bcgvZd7mLDxY1axBeFq8=
 github.com/aws/aws-sdk-go v1.28.4/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -87,12 +89,14 @@ github.com/davidlazar/go-crypto v0.0.0-20170701192655-dcfb0a7ac018/go.mod h1:rQY
 github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f h1:6itBiEUtu+gOzXZWn46bM5/qm8LlV6/byR7Yflx/y6M=
 github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f/go.mod h1:VZxzAIRPHRVNRKRo6AXrX9BJegn6il06VMTZVJYCIjQ=
 github.com/dgraph-io/badger v1.6.0-rc1/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
+github.com/dgraph-io/badger v1.6.0 h1:DshxFxZWXUcO0xX476VJC07Xsr6ZCBVRHKZ93Oh7Evo=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgraph-io/badger/v2 v2.0.0-20190620211019-41d170b5158f h1:vxg+rV4/+3GqzeZZdZUSjMlnbdUx0Vr65okIulvJNHk=
 github.com/dgraph-io/badger/v2 v2.0.0-20190620211019-41d170b5158f/go.mod h1:jUaIjOV835xZ/mCLG/8P/38ZxiT4bG/K1khDNZJxuwU=
 github.com/dgryski/go-farm v0.0.0-20180109070241-2de33835d102/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f h1:dDxpBYafY/GYpcl+LS4Bn3ziLPuEdGRkRjYAbSlWxSA=
 github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
@@ -301,6 +305,7 @@ github.com/ipfs/go-ds-badger v0.0.2/go.mod h1:Y3QpeSFWQf6MopLTiZD+VT6IC1yZqaGmjv
 github.com/ipfs/go-ds-badger v0.0.4 h1:zpAfddnYEZBX980c2a7PJHAlwlnSE4LVCjmUJYevgFc=
 github.com/ipfs/go-ds-badger v0.0.4/go.mod h1:UIu++7eal30eVc+njb9LyGgBoJ3F+Y5cBpvD/dwn5VQ=
 github.com/ipfs/go-ds-badger v0.0.5/go.mod h1:g5AuuCGmr7efyzQhLL8MzwqcauPojGPUaHzfGTzuE3s=
+github.com/ipfs/go-ds-badger v0.2.0 h1:3h0U3L4o0v7LT2qyK5GScXH23DoYxat+VU2a4Ldt8yo=
 github.com/ipfs/go-ds-badger v0.2.0/go.mod h1:471n2X/Qtk8rRO1iuxcgdwmHJdWjDj9VRGhaP/tvoZw=
 github.com/ipfs/go-ds-flatfs v0.0.2/go.mod h1:YsMGWjUieue+smePAWeH/YhHtlmEMnEGhiwIn6K6rEM=
 github.com/ipfs/go-ds-leveldb v0.0.1 h1:Z0lsTFciec9qYsyngAw1f/czhRU35qBLR2vhavPFgqA=
@@ -308,6 +313,7 @@ github.com/ipfs/go-ds-leveldb v0.0.1/go.mod h1:feO8V3kubwsEF22n0YRQCffeb79OOYIyk
 github.com/ipfs/go-ds-leveldb v0.0.2/go.mod h1:CWFeBh5IAAscWyG/QRH+lJaAlnLWjsfPSNs4teyPUp0=
 github.com/ipfs/go-ds-measure v0.0.1/go.mod h1:wiH6bepKsgyNKpz3nyb4erwhhIVpIxnZbsjN1QpVbbE=
 github.com/ipfs/go-ds-measure v0.1.0/go.mod h1:1nDiFrhLlwArTME1Ees2XaBOl49OoCgd2A3f8EchMSY=
+github.com/ipfs/go-ds-s3 v0.4.0 h1:ygxqOlUJSy6ruo6EDbXZcKidI3g0XMcH09o2h9o9RE0=
 github.com/ipfs/go-ds-s3 v0.4.0/go.mod h1:rQq9mxpZSysuS+1QVWvwmCMzsTizoUWORzfZXtkwJj4=
 github.com/ipfs/go-fs-lock v0.0.1/go.mod h1:DNBekbboPKcxs1aukPSaOtFA3QfSdi5C855v0i9XJ8Y=
 github.com/ipfs/go-hamt-ipld v0.0.13 h1:Jbt5ALTYnrzbcOBka11kAkgn3auvkQBGkKWjGRsQrio=
@@ -400,6 +406,7 @@ github.com/jbenet/goprocess v0.1.3 h1:YKyIEECS/XvcfHtBzxtjBBbWK+MbvA6dG8ASiqwvr1
 github.com/jbenet/goprocess v0.1.3/go.mod h1:5yspPrukOVuOLORacaBi858NqyClJPQxYZlqdZVfqY4=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 h1:rp+c0RAYOWj8l6qbCUTSiRLG/iKnW3K3/QfPPuSsBt4=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
@@ -839,6 +846,8 @@ github.com/quorumcontrol/tupelo v0.5.12-0.20200111205713-bdcd8177fb62/go.mod h1:
 github.com/quorumcontrol/tupelo v0.5.12-0.20200123190536-540022241c70/go.mod h1:jg2mK/ZptRCKhH/EQ61UaBzZJ7N2dG1E84Vy7E1Aen4=
 github.com/quorumcontrol/tupelo v0.5.12-0.20200129144132-3be48615b2ec h1:hRWIF9liOwv6MiB6y5dhzCLdNEGRTPWHJ0elmpIc+K8=
 github.com/quorumcontrol/tupelo v0.5.12-0.20200129144132-3be48615b2ec/go.mod h1:t0szRFOWJ03Mf8uCeqPWjdKrMVWjUNuMyKkDHIgVZ/M=
+github.com/quorumcontrol/tupelo v0.5.12-0.20200226160350-8bc73f1e0652 h1:YpEZC6mIewkGM0mf/GjAsct8pnM6RtMHEk0Yi+oyO2g=
+github.com/quorumcontrol/tupelo v0.5.12-0.20200226160350-8bc73f1e0652/go.mod h1:3+5xLTaAH0ldclLgxAVCkIMFRWqJH6AKKfbsY3NegTQ=
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1/go.mod h1:wA31G/DE4bI+8rsWKGRlxOgtKjrk0nJjd1qgRTpiN0Q=
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200107015105-2d3804ccc20c/go.mod h1:+WlZ8i77PW1SQ1oEZ700ooGuC3JOcxPiA5ij8PkKCqk=
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200109062614-43239ffb9335/go.mod h1:fzYef+fz7cbeMKU6pg+NkEX/7BhZfWD33/MaHS76qs8=
@@ -846,6 +855,7 @@ github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200111013635-908b6d63182
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200111041028-c872b16c033b/go.mod h1:eEl6oezYQDGnlM3Xfm6bFQJE4k/TjJC1f7nOGwhZHz0=
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200123190352-82ad6dc34f40/go.mod h1:5p17iUG+Kfpm173mL4mDSgNmUm9+3rFJ6B5Fi97TjHM=
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200129114839-0d0c6bc84fd3/go.mod h1:gix9XW6TZ1G9KieMw1aat2G9rAjBEtsaYb0pC818rFU=
+github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200226084025-d1ef23ea82c2/go.mod h1:FacTufzYlDnWnhChtBvOi2yix8bbYOs37/0m53zKuN0=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0 h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -1032,6 +1042,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191111213947-16651526fdb4 h1:AGVXd+IAyeAb3FuQvYDYQ9+WR2JHm0+C0oYJaU1C4rs=
 golang.org/x/crypto v0.0.0-20191111213947-16651526fdb4/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200204104054-c9f3fb736b72 h1:+ELyKg6m8UBf0nPFSqD0mi7zUfwPyXo23HNjMnXPz7w=
+golang.org/x/crypto v0.0.0-20200204104054-c9f3fb736b72/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=

--- a/gossip/client/client.go
+++ b/gossip/client/client.go
@@ -10,16 +10,21 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-hamt-ipld"
 	cbornode "github.com/ipfs/go-ipld-cbor"
+	format "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log"
+	"github.com/opentracing/opentracing-go"
 	"github.com/quorumcontrol/chaintree/chaintree"
 	"github.com/quorumcontrol/chaintree/dag"
 	"github.com/quorumcontrol/chaintree/nodestore"
+	"github.com/quorumcontrol/chaintree/safewrap"
 	"github.com/quorumcontrol/messages/v2/build/go/gossip"
 	"github.com/quorumcontrol/messages/v2/build/go/services"
 	"github.com/quorumcontrol/messages/v2/build/go/transactions"
+	"github.com/quorumcontrol/tupelo-go-sdk/bls"
 	"github.com/quorumcontrol/tupelo-go-sdk/consensus"
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip/client/pubsubinterfaces"
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip/types"
+	"github.com/quorumcontrol/tupelo-go-sdk/proof"
 )
 
 var ErrTimeout = errors.New("error timeout")
@@ -36,6 +41,9 @@ type Client struct {
 	subscriber *roundSubscriber
 	pubsub     pubsubinterfaces.Pubsubber
 	store      nodestore.DagStore
+
+	validators  []chaintree.BlockValidatorFunc
+	transactors map[transactions.Transaction_Type]chaintree.TransactorFunc
 }
 
 // New instantiates a Client specific to a ChainTree/NotaryGroup. The store should probably be a bitswap peer.
@@ -43,12 +51,23 @@ type Client struct {
 func New(group *types.NotaryGroup, pubsub pubsubinterfaces.Pubsubber, store nodestore.DagStore) *Client {
 	logger := logging.Logger("g4-client")
 	subscriber := newRoundSubscriber(logger, group, pubsub, store)
+
+	validators, err := blockValidators(context.TODO(), group)
+	if err != nil {
+		panic(fmt.Errorf("error in client create that should never happen: %w", err))
+	}
+
+	transactors := group.Config().Transactions
+
 	return &Client{
 		Group:      group,
 		logger:     logger,
 		subscriber: subscriber,
 		pubsub:     pubsub,
 		store:      store,
+
+		validators:  validators,
+		transactors: transactors,
 	}
 }
 
@@ -80,7 +99,118 @@ func (c *Client) PlayTransactions(ctx context.Context, tree *consensus.SignedCha
 		return nil, fmt.Errorf("error creating new tree: %w", err)
 	}
 	tree.ChainTree = newChainTree
+	tree.Proof = proof
 	return proof, nil
+}
+
+func (c *Client) GetLatest(parentCtx context.Context, did string) (*consensus.SignedChainTree, error) {
+	sp, ctx := opentracing.StartSpanFromContext(parentCtx, "client.GetLatest")
+	defer sp.Finish()
+
+	sw := &safewrap.SafeWrap{}
+
+	c.logger.Debugf("getting tip for latest")
+
+	proof, err := c.GetTip(ctx, did)
+	if err != nil {
+		return nil, fmt.Errorf("error getting tip: %w", err)
+	}
+
+	abr := proof.AddBlockRequest
+
+	// cast the new and previous tips from the ABR
+
+	newTip, err := cid.Cast(abr.NewTip)
+	if err != nil {
+		return nil, fmt.Errorf("error casting newTip: %w", err)
+	}
+
+	previousTip, err := cid.Cast(abr.PreviousTip)
+	if err != nil {
+		return nil, fmt.Errorf("error casting previousTip: %w", err)
+	}
+
+	// now we save all the state blocks into the store
+
+	cborNodes := make([]format.Node, len(abr.State))
+	for i, node := range abr.State {
+		cborNodes[i] = sw.Decode(node)
+	}
+	if sw.Err != nil {
+		return nil, fmt.Errorf("error decoding nodes: %w", sw.Err)
+	}
+
+	err = c.store.AddMany(ctx, cborNodes)
+	if err != nil {
+		return nil, fmt.Errorf("error adding nodes: %w", err)
+	}
+
+	// and get the block with headers
+
+	blockWithHeaders := &chaintree.BlockWithHeaders{}
+	err = cbornode.DecodeInto(abr.Payload, blockWithHeaders)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding payload; %w", err)
+	}
+
+	// first we're going to create a chaintree at the *previous* tip and then we're going to play the new
+	// BlockWithHeaders on there so that the *new* state blocks get added to the local store
+
+	var treeDag *dag.Dag
+	if abr.Height > 0 {
+		treeDag = dag.NewDag(ctx, previousTip, c.store)
+	} else {
+		treeDag = consensus.NewEmptyTree(ctx, string(abr.ObjectId), c.store)
+	}
+
+	tree, err := chaintree.NewChainTree(ctx, treeDag, c.validators, c.transactors)
+	if err != nil {
+		return nil, fmt.Errorf("error creating new tree: %w", err)
+	}
+
+	c.logger.Debugf("process block immutable")
+
+	newTree, valid, err := tree.ProcessBlockImmutable(ctx, blockWithHeaders)
+	if !valid || err != nil {
+		return nil, fmt.Errorf("error processing block: %w", err)
+	}
+
+	// sanity check the new tip
+	if !newTree.Dag.Tip.Equals(newTip) {
+		return nil, fmt.Errorf("error, tips did not match %s != %s", newTree.Dag.Tip.String(), newTip.String())
+	}
+
+	// return our signed chaintree with all the new blocks already in the client store
+	return &consensus.SignedChainTree{
+		ChainTree: newTree,
+		Proof:     proof,
+	}, nil
+}
+
+func (c *Client) WaitForFirstRound(ctx context.Context, timeout time.Duration) error {
+	ch := make(chan *types.RoundWrapper, 1)
+	defer close(ch)
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	sub, err := c.SubscribeToRounds(context.TODO(), ch)
+	if err != nil {
+		return fmt.Errorf("error subscribing: %w", err)
+	}
+	defer c.UnsubscribeFromRounds(sub)
+
+	doneCh := ctx.Done()
+
+	select {
+	case <-ch:
+		return nil
+	case <-timer.C:
+		return fmt.Errorf("timeout")
+	case <-doneCh:
+		c.logger.Warning("ctx closed before WaitForFirstRound")
+		return nil
+	}
 }
 
 func (c *Client) GetTip(ctx context.Context, did string) (*gossip.Proof, error) {
@@ -181,4 +311,23 @@ func (c *Client) SubscribeToAbr(ctx context.Context, abr *services.AddBlockReque
 
 func (c *Client) UnsubscribeFromAbr(s subscription) {
 	c.subscriber.unsubscribe(s)
+}
+
+func blockValidators(ctx context.Context, group *types.NotaryGroup) ([]chaintree.BlockValidatorFunc, error) {
+	quorumCount := group.QuorumCount()
+	signers := group.AllSigners()
+	verKeys := make([]*bls.VerKey, len(signers))
+	for i, signer := range signers {
+		verKeys[i] = signer.VerKey
+	}
+
+	proofVerifier := types.GenerateHasValidProof(func(prf *gossip.Proof) (bool, error) {
+		return proof.Verify(ctx, prf, quorumCount, verKeys)
+	})
+
+	blockValidators, err := group.BlockValidators(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error getting block validators: %v", err)
+	}
+	return append(blockValidators, proofVerifier), nil
 }

--- a/gossip/client/client.go
+++ b/gossip/client/client.go
@@ -188,6 +188,11 @@ func (c *Client) GetLatest(parentCtx context.Context, did string) (*consensus.Si
 }
 
 func (c *Client) WaitForFirstRound(ctx context.Context, timeout time.Duration) error {
+	current := c.subscriber.Current()
+	if current != nil {
+		return nil
+	}
+
 	ch := make(chan *types.RoundWrapper, 1)
 	defer close(ch)
 

--- a/gossip/client/client_test.go
+++ b/gossip/client/client_test.go
@@ -91,7 +91,7 @@ func newClient(ctx context.Context, group *types.NotaryGroup, bootAddrs []string
 		return nil, err
 	}
 
-	err = cliHost.WaitForBootstrap(len(group.AllSigners()), 5*time.Second)
+	err = cliHost.WaitForBootstrap(len(group.AllSigners()), 30*time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/gossip/client/processblocks.go
+++ b/gossip/client/processblocks.go
@@ -73,7 +73,7 @@ func (c *Client) NewAddBlockRequest(ctx context.Context, tree *consensus.SignedC
 		state = append(nodesToBytes(touchedNodes))
 	}
 
-	// TODO: this is an expedient way to make sure the signers bitswap our new state for us
+	// TODO: sending in the *new* nodes is an expedient way to make sure the signers bitswap our new state for us
 	// but it will cost more in transaction fees and so should be rexamined in the future.
 	newNodes, err := tracker.newNodes(ctx)
 	if err != nil {

--- a/gossip/client/reftracking.go
+++ b/gossip/client/reftracking.go
@@ -11,6 +11,16 @@ import (
 
 type cidTracker map[cid.Cid]struct{}
 
+func (ct cidTracker) toSlice() []cid.Cid {
+	ids := make([]cid.Cid, len(ct))
+	i := 0
+	for k := range ct {
+		ids[i] = k
+		i++
+	}
+	return ids
+}
+
 /**
 storeWrapper keeps tracks of all the Gets and Adds in a DagStore.
 We use this because we want to know what from the previous state needs to be sent up to a Tupelo Signer
@@ -20,14 +30,14 @@ but there is no reason to send those up to Tupelo in the state of the Tx.
 */
 type storeWrapper struct {
 	nodestore.DagStore
-	touched  cidTracker
-	newNodes cidTracker
+	touched cidTracker
+	added   cidTracker
 }
 
 func (sw *storeWrapper) Get(ctx context.Context, id cid.Cid) (format.Node, error) {
 	n, err := sw.DagStore.Get(ctx, id)
 	if err == nil && n != nil {
-		if _, ok := sw.newNodes[id]; !ok {
+		if _, ok := sw.added[id]; !ok {
 			sw.touched[id] = struct{}{}
 		}
 	}
@@ -37,23 +47,20 @@ func (sw *storeWrapper) Get(ctx context.Context, id cid.Cid) (format.Node, error
 func (sw *storeWrapper) Add(ctx context.Context, n format.Node) error {
 	err := sw.DagStore.Add(ctx, n)
 	if err == nil {
-		sw.newNodes[n.Cid()] = struct{}{}
+		sw.added[n.Cid()] = struct{}{}
 	}
 	return err
 }
 
-func (sw *storeWrapper) touchedCids() []cid.Cid {
-	ids := make([]cid.Cid, len(sw.touched))
-	i := 0
-	for k := range sw.touched {
-		ids[i] = k
-		i++
-	}
-	return ids
+func (sw *storeWrapper) touchedNodes(ctx context.Context) ([]format.Node, error) {
+	return sw.cidToNodes(ctx, sw.touched.toSlice())
 }
 
-func (sw *storeWrapper) touchedNodes(ctx context.Context) ([]format.Node, error) {
-	ids := sw.touchedCids()
+func (sw *storeWrapper) newNodes(ctx context.Context) ([]format.Node, error) {
+	return sw.cidToNodes(ctx, sw.added.toSlice())
+}
+
+func (sw *storeWrapper) cidToNodes(ctx context.Context, ids []cid.Cid) ([]format.Node, error) {
 	nodes := make([]format.Node, len(ids))
 	for i, id := range ids {
 		n, err := sw.DagStore.Get(ctx, id)
@@ -69,6 +76,6 @@ func wrapStoreForRefCounting(store nodestore.DagStore) *storeWrapper {
 	return &storeWrapper{
 		DagStore: store,
 		touched:  make(cidTracker),
-		newNodes: make(cidTracker),
+		added:    make(cidTracker),
 	}
 }

--- a/wasm/jsclient/jsclient.go
+++ b/wasm/jsclient/jsclient.go
@@ -7,6 +7,7 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"syscall/js"
+	"time"
 
 	"github.com/quorumcontrol/tupelo-go-sdk/bls"
 
@@ -158,16 +159,12 @@ func (jsc *JSClient) PlayTransactions(jsKeyBits js.Value, tip js.Value, jsTransa
 func (jsc *JSClient) WaitForRound() *then.Then {
 	t := then.New()
 	go func() {
-		ch := make(chan *types.RoundWrapper, 1)
-
-		sub, err := jsc.client.SubscribeToRounds(context.TODO(), ch)
+		err := jsc.client.WaitForFirstRound(context.TODO(), 30*time.Second)
 		if err != nil {
 			t.Reject(err)
 			return
 		}
-		<-ch
-		jsc.client.UnsubscribeFromRounds(sub)
-		close(ch)
+
 		t.Resolve(nil)
 	}()
 


### PR DESCRIPTION
* refactor SignedChainTree to use proof instead of a signaturemap (I can't find any external to the sdk uses)
* add a WaitForFirstRound() to the client
* adds GetLatest to client which gets the latest ABR, plays the transactions locally on that ABR (in order to make the new blocks available) and then returns a SignedChainTree at the latest tip with the proof
* send in the *new* blocks along with the existing blocks in order to have the signers make the new state available.

I think that last point there might be controversial and there are a few ways to do it, but this one works... it makes Txs bigger but that should be OK for now. 