### PR TITLE
Make round subscriber to return RoundConfirmationWrapper to match Current

### DIFF
--- a/gossip/client/client.go
+++ b/gossip/client/client.go
@@ -193,7 +193,7 @@ func (c *Client) WaitForFirstRound(ctx context.Context, timeout time.Duration) e
 		return nil
 	}
 
-	ch := make(chan *types.RoundWrapper, 1)
+	ch := make(chan *types.RoundConfirmationWrapper, 1)
 	defer close(ch)
 
 	timer := time.NewTimer(timeout)
@@ -298,9 +298,9 @@ func (c *Client) SendWithoutWait(ctx context.Context, abr *services.AddBlockRequ
 	return nil
 }
 
-func (c *Client) SubscribeToRounds(ctx context.Context, ch chan *types.RoundWrapper) (subscription, error) {
+func (c *Client) SubscribeToRounds(ctx context.Context, ch chan *types.RoundConfirmationWrapper) (subscription, error) {
 	return c.subscriber.stream.Subscribe(func(evt interface{}) {
-		ch <- evt.(*ValidationNotification).CompletedRound
+		ch <- evt.(*ValidationNotification).RoundConfirmation
 	}), nil
 }
 

--- a/gossip/client/client_test.go
+++ b/gossip/client/client_test.go
@@ -204,7 +204,7 @@ func TestClientSendTransactions(t *testing.T) {
 		blockWithHeaders0 := transactLocal(ctx, t, testTree, treeKey, 0, "down/in/the/tree", "atestvalue")
 		tip0 := testTree.Tip()
 
-		roundCh := make(chan *types.RoundWrapper, 10)
+		roundCh := make(chan *types.RoundConfirmationWrapper, 10)
 		roundSubscription, err := cli.SubscribeToRounds(ctx, roundCh)
 		require.Nil(t, err)
 		defer cli.UnsubscribeFromRounds(roundSubscription)


### PR DESCRIPTION
The additional data inside `RoundConfirmationWrapper` may also be useful. `RoundWrapper` is still accessible within the confirmation also