### PR TITLE
Fix services.AddBlockRequest cbor registration

### DIFF
--- a/gossip/types/rounds.go
+++ b/gossip/types/rounds.go
@@ -9,8 +9,8 @@ import (
 	cbornode "github.com/ipfs/go-ipld-cbor"
 	"github.com/quorumcontrol/chaintree/nodestore"
 	"github.com/quorumcontrol/chaintree/safewrap"
-	"github.com/quorumcontrol/messages/build/go/services"
 	"github.com/quorumcontrol/messages/v2/build/go/gossip"
+	"github.com/quorumcontrol/messages/v2/build/go/services"
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip/hamtwrapper"
 )
 

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -9,7 +9,6 @@ import (
 
 	cbornode "github.com/ipfs/go-ipld-cbor"
 	logging "github.com/ipfs/go-log"
-	"github.com/quorumcontrol/messages/v2/build/go/services"
 
 	"github.com/quorumcontrol/tupelo-go-sdk/wasm/jsclient"
 	"github.com/quorumcontrol/tupelo-go-sdk/wasm/jslibs"
@@ -23,8 +22,6 @@ var exitChan chan bool
 var clientSingleton *jsclient.JSClient
 
 func init() {
-	cbornode.RegisterCborType(services.AddBlockRequest{})
-
 	exitChan = make(chan bool)
 }
 


### PR DESCRIPTION
`gossip/types/rounds.go ` was registering `v1` instead of `v2`

This build will fail because tupelo also registered this