### PR TITLE
Ensure reference-able Errs are propagated in GetLatest

### DIFF
--- a/gossip/client/client.go
+++ b/gossip/client/client.go
@@ -112,6 +112,12 @@ func (c *Client) GetLatest(parentCtx context.Context, did string) (*consensus.Si
 	c.logger.Debugf("getting tip for latest")
 
 	proof, err := c.GetTip(ctx, did)
+	if err == ErrNotFound {
+		return nil, ErrNotFound
+	}
+	if err == ErrNoRound {
+		return nil, ErrNoRound
+	}
 	if err != nil {
 		return nil, fmt.Errorf("error getting tip: %w", err)
 	}


### PR DESCRIPTION
`GetLatest` was wrapping known errors, which makes it hard for clients to do conditional logic safely. This fixes that by propagating `ErrNotFound` and `ErrNoRound` from `GetTip`