### PR TITLE
Make GetTip / GetLatest wait for round to exist

### DIFF
--- a/gossip/client/client_test.go
+++ b/gossip/client/client_test.go
@@ -32,6 +32,11 @@ import (
 
 const groupMembers = 3
 
+func init() {
+	// round heartbeat should be fast in tests with no latency
+	DefaultRoundWaitTimeout = 1 * time.Second
+}
+
 func newTupeloSystem(ctx context.Context, testSet *testnotarygroup.TestSet) (*types.NotaryGroup, []*tupelogossip.Node, error) {
 	nodes := make([]*tupelogossip.Node, len(testSet.SignKeys))
 


### PR DESCRIPTION
When clients don't yet have a round, try and fetch one on "Get" requests, that is `GetTip` and `GetLatest` - this prevents confusing behavior where `Get` sometimes works, but sometimes doesn't depending on if you've received a heartbeat after start up. Most of the time, `subscriber.Current()` will already be set and the added logic will be a noop. 