### PR TITLE
fix error propagation test

### DIFF
--- a/gossip/client/client.go
+++ b/gossip/client/client.go
@@ -113,11 +113,8 @@ func (c *Client) GetLatest(parentCtx context.Context, did string) (*consensus.Si
 	c.logger.Debugf("getting tip for latest")
 
 	proof, err := c.GetTip(ctx, did)
-	if err == ErrNotFound {
-		return nil, ErrNotFound
-	}
-	if err == ErrNoRound {
-		return nil, ErrNoRound
+	if (err == ErrNotFound) || (err == ErrNoRound) {
+		return nil, err
 	}
 	if err != nil {
 		return nil, fmt.Errorf("error getting tip: %w", err)

--- a/gossip/client/client_test.go
+++ b/gossip/client/client_test.go
@@ -403,6 +403,28 @@ func TestGetLatest(t *testing.T) {
 
 	startNodes(t, ctx, nodes, bootAddrs)
 
+	// This must remain the first Run in this test block
+	t.Run("test known Err propogation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		cli1, err := newClient(ctx, group, bootAddrs)
+		require.Nil(t, err)
+
+		treeKey, err := crypto.GenerateKey()
+		require.Nil(t, err)
+
+		tree, err := cli1.GetLatest(ctx, consensus.EcdsaPubkeyToDid(treeKey.PublicKey))
+		require.Nil(t, tree)
+		require.Equal(t, err, ErrNoRound)
+
+		startRounds(t, ctx, group, bootAddrs)
+
+		tree, err = cli1.GetLatest(ctx, consensus.EcdsaPubkeyToDid(treeKey.PublicKey))
+		require.Nil(t, tree)
+		require.Equal(t, err, ErrNotFound)
+	})
+
 	t.Run("test basic setup", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
@@ -487,27 +509,6 @@ func TestGetLatest(t *testing.T) {
 		t.Logf("remain: %v", remain)
 		require.Nil(t, err)
 		require.Equal(t, true, resp)
-	})
-
-	t.Run("test known Err propogation", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
-
-		cli1, err := newClient(ctx, group, bootAddrs)
-		require.Nil(t, err)
-
-		treeKey, err := crypto.GenerateKey()
-		require.Nil(t, err)
-
-		tree, err := cli1.GetLatest(ctx, consensus.EcdsaPubkeyToDid(treeKey.PublicKey))
-		require.Nil(t, tree)
-		require.Equal(t, err, ErrNoRound)
-
-		startRounds(t, ctx, group, bootAddrs)
-
-		tree, err = cli1.GetLatest(ctx, consensus.EcdsaPubkeyToDid(treeKey.PublicKey))
-		require.Nil(t, tree)
-		require.Equal(t, err, ErrNotFound)
 	})
 }
 


### PR DESCRIPTION
the error propagation PR #205 ended up having a real test failure upon merging to master because #206 changed the "no round" behavior - this fixes that test