### PR TITLE
allow configurable transports in libp2p

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/libp2p/go-libp2p-pnet v0.1.0
 	github.com/libp2p/go-libp2p-pubsub v0.1.1
 	github.com/libp2p/go-libp2p-swarm v0.2.2
+	github.com/libp2p/go-tcp-transport v0.1.1
 	github.com/multiformats/go-multiaddr v0.1.1
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.8.1

--- a/p2p/config.go
+++ b/p2p/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	ListenIP             string
 	DiscoveryNamespaces  []string
 	AdditionalP2POptions []libp2p.Option
+	Transports           []libp2p.Option // these should only be libp2p.Transport options, but can't detect that with type
 	DataStore            ds.Batching
 	Blockstore           blockstore.Blockstore
 	BandwidthReporter    metrics.Reporter
@@ -277,7 +278,7 @@ func WithClientOnlyDHT(isClientOnly bool) Option {
 	}
 }
 
-// With Libp2pOptions allows for additional libp2p options to be passed in
+// WithLibp2pOptions allows for additional libp2p options to be passed in
 func WithLibp2pOptions(opts ...libp2p.Option) Option {
 	return func(c *Config) error {
 		c.AdditionalP2POptions = opts
@@ -288,6 +289,15 @@ func WithLibp2pOptions(opts ...libp2p.Option) Option {
 func WithBitswapOptions(opts ...bitswap.Option) Option {
 	return func(c *Config) error {
 		c.BitswapOptions = opts
+		return nil
+	}
+}
+
+// WithTransports should only be used with a libp2p.Transport option
+// but cannot detect that using typing
+func WithTransports(transports ...libp2p.Option) Option {
+	return func(c *Config) error {
+		c.Transports = transports
 		return nil
 	}
 }

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -166,10 +166,17 @@ func newLibP2PHostFromConfig(ctx context.Context, c *Config) (*LibP2PHost, error
 		c.ListenAddrs = append(c.ListenAddrs, fmt.Sprintf("/ip4/%s/tcp/%d/ws", ip, c.WebsocketPort))
 	}
 
+	var transports libp2p.Option
+	if len(c.Transports) == 0 {
+		transports = libp2p.DefaultTransports
+	} else {
+		transports = libp2p.ChainOptions(c.Transports...)
+	}
+
 	opts := []libp2p.Option{
 		libp2p.ListenAddrStrings(c.ListenAddrs...),
 		libp2p.Identity(priv),
-		libp2p.DefaultTransports,
+		transports,
 		libp2p.DefaultMuxers,
 		libp2p.DefaultSecurity,
 		libp2p.BandwidthReporter(c.BandwidthReporter),

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/libp2p/go-libp2p"
 	circuit "github.com/libp2p/go-libp2p-circuit"
 	connmgr "github.com/libp2p/go-libp2p-connmgr"
+	"github.com/libp2p/go-tcp-transport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -70,6 +71,15 @@ func TestWithExternalAddrs(t *testing.T) {
 		"/ip4/2.2.2.2/tcp/53",
 		"/ip4/2.2.2.2/tcp/80/ws",
 	})
+}
+
+func TestWithTransports(t *testing.T) {
+	c := &Config{}
+	transport := libp2p.Transport(tcp.NewTCPTransport)
+	err := applyOptions(c, WithTransports(transport))
+	require.Nil(t, err)
+	require.Len(t, c.Transports, 1)
+	// for some reason equality assertion doesn't work.
 }
 
 func TestNewRelayLibP2PHost(t *testing.T) {


### PR DESCRIPTION
I couldn't figure out how to better filter out websockets from dials (filters seem only supported on IP addresses). This allows a configurable transport on a libp2p node (overriding the defaults). 

I use this over in Tupelo to construct a wrapped websocket transport that has CanDial set to false.