### PR TITLE
add CurrentRound to tupelo client

### DIFF
--- a/gossip/client/client.go
+++ b/gossip/client/client.go
@@ -191,6 +191,10 @@ func (c *Client) GetLatest(parentCtx context.Context, did string) (*consensus.Si
 	}, nil
 }
 
+func (c *Client) CurrentRound() *types.RoundConfirmationWrapper {
+	return c.subscriber.Current()
+}
+
 func (c *Client) WaitForFirstRound(ctx context.Context, timeout time.Duration) error {
 	current := c.subscriber.Current()
 	if current != nil {

--- a/gossip/client/client_test.go
+++ b/gossip/client/client_test.go
@@ -249,6 +249,11 @@ func TestClientSendTransactions(t *testing.T) {
 		<-respCh1
 
 		require.Len(t, roundCh, 2)
+
+		round1 := <-roundCh
+		require.NotEqual(t, round1, cli.CurrentRound())
+		round2 := <-roundCh
+		require.Equal(t, round2, cli.CurrentRound())
 	})
 
 	t.Run("transactions played out of order succeed", func(t *testing.T) {


### PR DESCRIPTION
In the metric measurement, I had the whole "subscribe, wait and grab one round, then unsubscribe" in order to get the current round. That seems valuable here instead.