### PR TITLE
Add all dag nodes in testhelpers

### DIFF
--- a/gossip/testhelpers/helpers.go
+++ b/gossip/testhelpers/helpers.go
@@ -57,7 +57,7 @@ func NewValidTransactionWithPathAndValue(t testing.TB, treeKey *ecdsa.PrivateKey
 
 	_, err = testTree.ProcessBlock(ctx, blockWithHeaders)
 	require.Nil(t, err)
-	nodes := DagToByteNodes(t, emptyTree)
+	nodes := DagToByteNodes(t, testTree.Dag)
 
 	bits := sw.WrapObject(blockWithHeaders).RawData()
 	require.Nil(t, sw.Err)


### PR DESCRIPTION
This updates the `NewValidTransaction` helpers to send over their new tree dag nodes, which is the same behavior the client uses during play transactions