### PR TITLE
add function to create named chaintrees to client module

### DIFF
--- a/gossip/client/namedtree.go
+++ b/gossip/client/namedtree.go
@@ -1,0 +1,113 @@
+package client
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"strings"
+
+	"github.com/quorumcontrol/chaintree/chaintree"
+	"github.com/quorumcontrol/chaintree/nodestore"
+	"github.com/quorumcontrol/messages/v2/build/go/transactions"
+	"github.com/quorumcontrol/tupelo-go-sdk/consensus"
+)
+
+type Generator struct {
+	Namespace string
+	Client    *Client
+}
+
+type NamedChainTree struct {
+	Name      string
+	ChainTree *consensus.SignedChainTree
+	Client    *Client
+
+	genesisKey *ecdsa.PrivateKey
+	nodeStore  nodestore.DagStore
+	owners     []string
+}
+
+type Options struct {
+	Name              string
+	ObjectStorageType string
+	Client            *Client
+	NodeStore         nodestore.DagStore
+	Owners            []string
+}
+
+// GenesisKey creates a new named key creation key based on the supplied name.
+// It lower-cases the name first to ensure that chaintree names are case
+// insensitive.
+func (g *Generator) GenesisKey(name string) (*ecdsa.PrivateKey, error) {
+	// TODO: If we ever want case sensitivity, consider adding a bool flag
+	// to the Generator or adding a new fun.
+	lowerCased := strings.ToLower(name)
+	return consensus.PassPhraseKey([]byte(lowerCased), []byte(g.Namespace))
+}
+
+func (g *Generator) New(ctx context.Context, opts *Options) (*NamedChainTree, error) {
+	gKey, err := g.GenesisKey(opts.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	chainTree, err := consensus.NewSignedChainTree(ctx, gKey.PublicKey, opts.NodeStore)
+	if err != nil {
+		return nil, err
+	}
+
+	setOwnershipTxn, err := chaintree.NewSetOwnershipTransaction(opts.Owners)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = opts.Client.PlayTransactions(ctx, chainTree, gKey, []*transactions.Transaction{setOwnershipTxn})
+	if err != nil {
+		return nil, err
+	}
+
+	return &NamedChainTree{
+		Name:       opts.Name,
+		ChainTree:  chainTree,
+		genesisKey: gKey,
+		Client:     opts.Client,
+		nodeStore:  opts.NodeStore,
+		owners:     opts.Owners,
+	}, nil
+}
+
+func (g *Generator) Did(name string) (string, error) {
+	gKey, err := g.GenesisKey(name)
+	if err != nil {
+		return "", err
+	}
+
+	return consensus.EcdsaPubkeyToDid(gKey.PublicKey), nil
+}
+
+func (g *Generator) Find(ctx context.Context, name string) (*NamedChainTree, error) {
+	did, err := g.Did(name)
+	if err != nil {
+		return nil, err
+	}
+
+	chainTree, err := g.Client.GetLatest(ctx, did)
+	if err == ErrNotFound {
+		return nil, ErrNotFound
+	}
+
+	gKey, err := g.GenesisKey(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &NamedChainTree{
+		Name:       name,
+		ChainTree:  chainTree,
+		genesisKey: gKey,
+		Client:     g.Client,
+	}, nil
+}
+
+func (t *NamedChainTree) Did() string {
+	return consensus.EcdsaPubkeyToDid(t.genesisKey.PublicKey)
+}

--- a/gossip/client/namedtree.go
+++ b/gossip/client/namedtree.go
@@ -26,7 +26,7 @@ type NamedChainTree struct {
 	owners     []string
 }
 
-type Options struct {
+type NamedChainTreeOptions struct {
 	Name              string
 	ObjectStorageType string
 	Client            *Client
@@ -44,7 +44,7 @@ func (g *Generator) GenesisKey(name string) (*ecdsa.PrivateKey, error) {
 	return consensus.PassPhraseKey([]byte(lowerCased), []byte(g.Namespace))
 }
 
-func (g *Generator) New(ctx context.Context, opts *Options) (*NamedChainTree, error) {
+func (g *Generator) New(ctx context.Context, opts *NamedChainTreeOptions) (*NamedChainTree, error) {
 	gKey, err := g.GenesisKey(opts.Name)
 	if err != nil {
 		return nil, err

--- a/wasm/jsclient/jsclient.go
+++ b/wasm/jsclient/jsclient.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/quorumcontrol/tupelo-go-sdk/bls"
 
-	"github.com/ipfs/go-cid"
+	cid "github.com/ipfs/go-cid"
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip/client"
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip/client/pubsubinterfaces"
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip/types"
@@ -349,6 +349,36 @@ func NewEmptyTree(jsBlockService js.Value, jsPublicKeyBits js.Value) *then.Then 
 		dag := consensus.NewEmptyTree(ctx, did, store)
 		t.Resolve(helpers.CidToJSCID(dag.Tip))
 	}()
+	return t
+}
+
+// NewNamedTree creates a new ChainTree who's id is deterministically generated
+// from both a namespace and name, but is owned by the specified owner keys.
+func (jsc *JSClient) NewNamedTree(jsNamespace js.Value, jsName js.Value, jsOwners js.Value, jsBlockService js.Value) *then.Then {
+	t := then.New()
+	ctx := context.TODO()
+	go func() {
+		namespace := jsNamespace.String()
+		name := jsName.String()
+
+		ownerLength := jsOwners.Length()
+		owners := make([]string, ownerLength)
+		for i := 0; i < ownerLength; i++ {
+			owners[i] = jsOwners.Index(i).String()
+		}
+
+		opts := client.NamedChainTreeOptions{Name: name, Owners: owners}
+		gen := client.NewGenerator(jsc.client, namespace)
+
+		tree, err := gen.Create(ctx, &opts)
+		if err != nil {
+			t.Reject(err)
+			return
+		}
+
+		t.Resolve(helpers.CidToJSCID(tree.Tip))
+	}()
+
 	return t
 }
 

--- a/wasm/jsclient/jsclient.go
+++ b/wasm/jsclient/jsclient.go
@@ -354,7 +354,7 @@ func NewEmptyTree(jsBlockService js.Value, jsPublicKeyBits js.Value) *then.Then 
 
 // NewNamedTree creates a new ChainTree who's id is deterministically generated
 // from both a namespace and name, but is owned by the specified owner keys.
-func (jsc *JSClient) NewNamedTree(jsNamespace js.Value, jsName js.Value, jsOwners js.Value, jsBlockService js.Value) *then.Then {
+func (jsc *JSClient) NewNamedTree(jsNamespace js.Value, jsName js.Value, jsOwners js.Value) *then.Then {
 	t := then.New()
 	ctx := context.TODO()
 	go func() {

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -74,6 +74,10 @@ func main() {
 				return jsclient.EcdsaPubkeyToAddress(args[0])
 			}))
 
+			jsObj.Set("newNamedTree", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+				return jsclient.NewNamedTree(args[0], args[1], args[2])
+			}))
+
 			jsObj.Set("newEmptyTree", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 				return jsclient.NewEmptyTree(args[0], args[1])
 			}))


### PR DESCRIPTION
Provides general purpose functions to create named chain trees. The core of this was taken from https://github.com/quorumcontrol/dgit/pull/54/files#diff-76322c32928676af84ceb283d452ee8fR1. 